### PR TITLE
Keepalive, Pause, Teardown, Bug fix

### DIFF
--- a/RTSP/Messages/RTSPRequest.cs
+++ b/RTSP/Messages/RTSPRequest.cs
@@ -71,13 +71,17 @@ namespace Rtsp.Messages
                 case RequestType.PLAY:
                     returnValue = new RtspRequestPlay();
                     break;
+                case RequestType.PAUSE:
+                    returnValue = new RtspRequestPause();
+                    break;
+                case RequestType.TEARDOWN:
+                    returnValue = new RtspRequestTeardown();
+                    break;
+
                     /*
                 case RequestType.ANNOUNCE:
                     break;
                 case RequestType.GET_PARAMETER:
-                    break;
-
-                case RequestType.PAUSE:
                     break;
 
                 case RequestType.RECORD:
@@ -86,8 +90,6 @@ namespace Rtsp.Messages
                     break;
                 
                 case RequestType.SET_PARAMETER:
-                    break;
-                case RequestType.TEARDOWN:
                     break;
                      */
                 case RequestType.UNKNOWN:

--- a/RTSP/Messages/RTSPRequestPause.cs
+++ b/RTSP/Messages/RTSPRequestPause.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rtsp.Messages
+{
+    public class RtspRequestPause : RtspRequest
+    {
+
+        // Constructor
+        public RtspRequestPause()
+        {
+            Command = "PAUSE * RTSP/1.0";
+        }
+    }
+}

--- a/RTSP/Messages/RTSPRequestTeardown.cs
+++ b/RTSP/Messages/RTSPRequestTeardown.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rtsp.Messages
+{
+    public class RtspRequestTeardown : RtspRequest
+    {
+
+        // Constructor
+        public RtspRequestTeardown()
+        {
+            Command = "TEARDOWN * RTSP/1.0";
+        }
+    }
+}

--- a/RTSP/RTSP.csproj
+++ b/RTSP/RTSP.csproj
@@ -75,8 +75,10 @@
     <Compile Include="Messages\RTSPRequest.cs" />
     <Compile Include="Messages\RTSPRequestDescribe.cs" />
     <Compile Include="Messages\RTSPRequestOptions.cs" />
+    <Compile Include="Messages\RTSPRequestPause.cs" />
     <Compile Include="Messages\RTSPRequestPlay.cs" />
     <Compile Include="Messages\RTSPRequestSetup.cs" />
+    <Compile Include="Messages\RTSPRequestTeardown.cs" />
     <Compile Include="Messages\RTSPResponse.cs" />
     <Compile Include="Messages\RTSPTransport.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -146,7 +146,12 @@
                                     _sentMessage.Remove(response.CSeq);
                                     response.OriginalRequest = originalRequest;
                                     // restore the original sequence number.
+                                    /*
+                                    // Restoring the original CSeq sqeuence number was used on the original RTSP Multiplexer project
+		                            // For a normal RTSP Client example this is not needed and is currently commented out
+
                                     response.CSeq = originalRequest.CSeq;
+                                    */
                                 }
                                 else
                                 {

--- a/RtspClientExample/Program.cs
+++ b/RtspClientExample/Program.cs
@@ -420,9 +420,11 @@ namespace RtspClientExample
                             }
 
                             // Split the fmtp to get the sprop-parameter-sets which hold the SPS and PPS in base64
+                            // Then trim each item to remove whitespace after the semi colon
                             String[] split_fmtp = fmtp.Split(';');
-                            foreach (String item in split_fmtp)
+                            foreach (String raw_item in split_fmtp)
                             {
+                            	String item = raw_item.Trim();
                                 if (item.StartsWith("sprop-parameter-sets="))
                                 {
                                     List<byte[]> sps_pps = new List<byte[]>();


### PR DESCRIPTION
I have added a Keepalive to my RTSP Client example.
This required me to undo a CSeq re-write so this commit BREAKs the Multiplexer example

I also added Pause and Teardown (tested in another test programme not in this commit).

The pull request also fixes a bug where there was whitespace after the ';' symbol in the SDP where the H264 SPS and PPS are stored that showed up on the Axis IP Encoder
