### PR TITLE
RTSP Camera Server example

### DIFF
--- a/RTSP/Messages/RTSPRequest.cs
+++ b/RTSP/Messages/RTSPRequest.cs
@@ -77,11 +77,12 @@ namespace Rtsp.Messages
                 case RequestType.TEARDOWN:
                     returnValue = new RtspRequestTeardown();
                     break;
+                case RequestType.GET_PARAMETER:
+                    returnValue = new RtspRequestGetParameter();
+                    break;
 
                     /*
                 case RequestType.ANNOUNCE:
-                    break;
-                case RequestType.GET_PARAMETER:
                     break;
 
                 case RequestType.RECORD:

--- a/RTSP/Messages/RTSPRequestGetParameter.cs
+++ b/RTSP/Messages/RTSPRequestGetParameter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rtsp.Messages
+{
+    public class RtspRequestGetParameter : RtspRequest
+    {
+
+        // Constructor
+        public RtspRequestGetParameter()
+        {
+            Command = "GET_PARAMETER * RTSP/1.0";
+        }
+    }
+}

--- a/RTSP/RTSP.csproj
+++ b/RTSP/RTSP.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Messages\RTSPRequestPause.cs" />
     <Compile Include="Messages\RTSPRequestPlay.cs" />
     <Compile Include="Messages\RTSPRequestSetup.cs" />
+    <Compile Include="Messages\RTSPRequestGetParameter.cs" />
     <Compile Include="Messages\RTSPRequestTeardown.cs" />
     <Compile Include="Messages\RTSPResponse.cs" />
     <Compile Include="Messages\RTSPTransport.cs" />

--- a/RtspCameraExample/App.config
+++ b/RtspCameraExample/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/RtspCameraExample/Program.cs
+++ b/RtspCameraExample/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RtspCameraExample
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            RtspServer s = new RtspServer(8554);
+            s.StartListen();
+
+            // Wait for user to terminate programme
+            Console.WriteLine("Press ENTER to exit");
+            String dummy = Console.ReadLine();
+
+            s.StopListen();
+
+        }
+    }
+}

--- a/RtspCameraExample/Properties/AssemblyInfo.cs
+++ b/RtspCameraExample/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RtspCameraExample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RtspCameraExample")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5fa2077a-80e3-409a-9124-35a3d44b4a4e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RtspCameraExample/RtspCameraExample.csproj
+++ b/RtspCameraExample/RtspCameraExample.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DA8B426A-92A8-4944-B061-EC642EB0A4DA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RtspCameraExample</RootNamespace>
+    <AssemblyName>RtspCameraExample</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCard.cs" />
+    <Compile Include="TinyH264Encoder.cs" />
+    <Compile Include="RtspServer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RTSP\RTSP.csproj">
+      <Project>{0ad96152-eb0c-4f31-b4f4-583ce88a5046}</Project>
+      <Name>RTSP</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using Rtsp;
+using System.Text;
+using System.Collections.Generic;
+
+// RTSP Server Example by Roger Hardiman, 2016
+// Re-uses some code from the Multiplexer example of SharpRTSP
+//
+// This example simulates a live RTSP video stream, for example a CCTV Camera
+// It creates a Video Source (a test card) that creates a YUV Image
+// The image is then encoded as H264 data
+// The H264 data is sent to the RTSP clients
+
+// The Tiny H264 Encoder is a 100% .NET encoder which is lossless and creates large bitstreams as
+// there is no compression. It is limited to 128x96 resolution. However it makes it easy to write a quick
+// demo without needing native APIs or cross compiled C libraries for H264
+    
+    public class RtspServer : IDisposable
+    {
+
+        private TcpListener _RTSPServerListener;
+        private ManualResetEvent _Stopping;
+        private Thread _ListenTread;
+
+        private TestCard video_source = null;
+        private TinyH264Encoder h264_encoder = null;
+
+        List<RTPSession> rtp_list = new List<RTPSession>(); // list of RTSP Listeners, used when sending RTP over RTSP
+
+        Random rnd = new Random();
+        int session_count = 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RTSPServer"/> class.
+        /// </summary>
+        /// <param name="aPortNumber">A numero port.</param>
+        public RtspServer(int portNumber)
+        {
+            if (portNumber < System.Net.IPEndPoint.MinPort || portNumber > System.Net.IPEndPoint.MaxPort)
+                throw new ArgumentOutOfRangeException("aPortNumber", portNumber, "Port number must be between System.Net.IPEndPoint.MinPort and System.Net.IPEndPoint.MaxPort");
+            Contract.EndContractBlock();
+
+            RtspUtils.RegisterUri();
+            _RTSPServerListener = new TcpListener(IPAddress.Any, portNumber);
+        }
+
+        /// <summary>
+        /// Starts the listen.
+        /// </summary>
+        public void StartListen()
+        {
+            _RTSPServerListener.Start();
+            
+            _Stopping = new ManualResetEvent(false);
+            _ListenTread = new Thread(new ThreadStart(AcceptConnection));
+            _ListenTread.Start();
+
+            // Initialise the H264 encoder
+            h264_encoder = new TinyH264Encoder();
+
+            // Start the VideoSource
+            video_source = new TestCard(128, 96, 6);
+            video_source.ReceivedYUVFrame += video_source_ReceivedYUVFrame;
+        }
+
+
+        /// <summary>
+        /// Accepts the connection.
+        /// </summary>
+        private void AcceptConnection()
+        {
+            try
+            {
+                while (!_Stopping.WaitOne(0))
+                {
+                    TcpClient oneClient = _RTSPServerListener.AcceptTcpClient();
+                    var rtsp_socket = new RtspTcpTransport(oneClient);
+                    RtspListener newListener = new RtspListener(rtsp_socket);
+                    newListener.MessageReceived += RTSP_Message_Received;
+                    //RTSPDispatcher.Instance.AddListener(newListener);
+                    newListener.Start();
+                }
+            }
+            catch (SocketException error)
+            {
+               // _logger.Warn("Got an error listening, I have to handle the stopping which also throw an error", error);
+            }
+            catch (Exception error)
+            {
+               // _logger.Error("Got an error listening...", error);
+                throw;
+            }
+
+
+        }
+
+
+        public void StopListen()
+        {
+            _RTSPServerListener.Stop();
+            _Stopping.Set();
+            _ListenTread.Join();
+        }
+
+        #region IDisposable Membres
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                StopListen();
+                _Stopping.Dispose();
+            }
+        }
+
+        #endregion
+
+        // Process each RTSP message that is received
+        private void RTSP_Message_Received(object sender, RtspChunkEventArgs e)
+        {
+            // Cast the 'sender' and 'e' into the RTSP Listener (the Socket) and the RTSP Message
+            Rtsp.RtspListener listener = sender as Rtsp.RtspListener;
+            Rtsp.Messages.RtspMessage message = e.Message as Rtsp.Messages.RtspMessage;
+
+            Console.WriteLine("RTSP message received " + message);
+
+            // Handle OPTIONS message
+            if (message is Rtsp.Messages.RtspRequestOptions)
+            {
+                // Create the reponse to OPTIONS
+                Rtsp.Messages.RtspResponse options_response = (e.Message as Rtsp.Messages.RtspRequestOptions).CreateResponse();
+                listener.SendMessage(options_response);
+            }
+
+            // Handle DESCRIBE message
+            if (message is Rtsp.Messages.RtspRequestDescribe)
+            {
+                String requested_url = (message as Rtsp.Messages.RtspRequestDescribe).RtspUri.ToString();
+                Console.WriteLine("Request for " + requested_url);
+
+                // TODO. Check the requsted_url is valid. In this example we accept any RTSP URL
+
+                // Make the Base64 SPS and PPS
+                byte[] raw_sps = h264_encoder.GetRawSPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
+                byte[] raw_pps = h264_encoder.GetRawPPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
+                String sps_str = Convert.ToBase64String(raw_sps);
+                String pps_str = Convert.ToBase64String(raw_pps);
+
+                StringBuilder sdp = new StringBuilder();
+
+                // Generate the SDP
+                // The sprop-parameter-sets provide the SPS and PPS for H264 video
+                // The packetization-mode defines the H264 over RTP payloads used but is Optional
+                sdp.Append("v=0\n");
+                sdp.Append("o=user 123 0 IN IP4 0.0.0.0\n");
+                sdp.Append("s=SharpRTSP Test Camera\n");
+                sdp.Append("m=video 0 RTP/AVP 96\n");
+                sdp.Append("c=IN IP4 0.0.0.0\n");
+                sdp.Append("a=control:trackID=0\n");
+                sdp.Append("a=rtpmap:96 H264/90000\n");
+                sdp.Append("a=fmtp:96 profile-level-id=42A01E; sprop-parameter-sets="+sps_str+","+pps_str+";\n");
+
+                byte[] sdp_bytes = Encoding.ASCII.GetBytes(sdp.ToString());
+
+                // Create the reponse to DESCRIBE
+                // This must include the Session Description Protocol (SDP)
+                Rtsp.Messages.RtspResponse describe_response = (e.Message as Rtsp.Messages.RtspRequestDescribe).CreateResponse();
+
+                describe_response.AddHeader("Content-Base: " + requested_url);
+                describe_response.AddHeader("Content-Type: application/sdp");
+                describe_response.Data = sdp_bytes;
+                describe_response.AdjustContentLength();
+                listener.SendMessage(describe_response);
+            }
+
+            // Handle SETUP message
+            if (message is Rtsp.Messages.RtspRequestSetup)
+            {
+                // Create a 'Session' and add it to the Session List
+                RTPSession new_session = new RTPSession();
+                new_session.session_id = session_count.ToString();
+                new_session.listener = listener;
+                new_session.sequence_number = rnd.Next(); // start with a random sequence number
+                new_session.ssrc = 1;
+                rtp_list.Add(new_session);
+                session_count++;
+
+                Rtsp.Messages.RtspResponse setup_response = (e.Message as Rtsp.Messages.RtspRequestSetup).CreateResponse();
+//                setup_response.AddHeader("Transport: RTP/AVP;unicast;client_port=8000-8001");
+                setup_response.AddHeader("Transport: RTP/AVP/TCP;interleaved=0-1");
+                setup_response.Session = new_session.session_id;
+                listener.SendMessage(setup_response);
+
+
+            }
+
+            // Handle PLAY message
+            if (message is Rtsp.Messages.RtspRequestPlay)
+            {
+                lock (rtp_list)
+                {
+                    // Search for the Session in the Sessions List. Change the state of "PLAY"
+                    foreach (RTPSession session in rtp_list)
+                    {
+                        if (session.session_id.Equals(message.Session)) {
+                            // found the session
+                            session.play = true;
+                            break;
+                        }
+                    }
+                }
+
+                // ToDo - only send back the OK response if the Session in the RTSP message was found
+                Rtsp.Messages.RtspResponse play_response = (e.Message as Rtsp.Messages.RtspRequestPlay).CreateResponse();
+                listener.SendMessage(play_response);
+            }
+
+            // Handle PLAUSE message
+            if (message is Rtsp.Messages.RtspRequestPause)
+            {
+                lock (rtp_list)
+                {
+                    // Search for the Session in the Sessions List. Change the state of "PLAY" 
+                    foreach (RTPSession session in rtp_list)
+                    {
+                        if (session.session_id.Equals(message.Session))
+                        {
+                            // found the session
+                            session.play = false;
+                            break;
+                        }
+                    }
+                }
+
+                // ToDo - only send back the OK response if the Session in the RTSP message was found
+                Rtsp.Messages.RtspResponse pause_response = (e.Message as Rtsp.Messages.RtspRequestPause).CreateResponse();
+                listener.SendMessage(pause_response);
+            }
+
+
+            // Handle GET_PARAMETER message, often used as a Keep Alive
+            if (message is Rtsp.Messages.RtspRequestGetParameter)
+            {
+                // Create the reponse to GET_PARAMETER
+                Rtsp.Messages.RtspResponse getparameter_response = (e.Message as Rtsp.Messages.RtspRequestGetParameter).CreateResponse();
+                listener.SendMessage(getparameter_response);
+            }
+
+        }
+
+        void video_source_ReceivedYUVFrame(uint timestamp, int width, int height, byte[] yuv_data)
+        {
+
+            // Take the YUV image and encode it into a H264 NAL
+            // This returns a NAL with no headers (no 00 00 00 01 header and no 32 bit sizes)
+            byte[] raw_nal = h264_encoder.CompressFrame(yuv_data);
+
+            // Go through each RTSP session and output the NAL
+            foreach (RTPSession session in rtp_list)
+            {
+
+                // Only process Sessions in Play Mode
+                if (session.play == false) continue;
+
+                // Build the RTP packet(s) for this client
+                List<byte> rtp_packet = new List<byte>();
+
+                // RTP Packet Header
+                // 0 - Version, P, X, CC, M, PT and Sequence Number
+                //32 - Timestamp
+                //64 - SSRC
+                //96 - CSRCs (optional)
+                //nn - Extension ID and Length
+                //nn - Extension header
+
+                int rtp_version = 2;
+                int rtp_padding = 0;
+                int rtp_extension = 0;
+                int rtp_csrc_count = 0;
+                int rtp_marker = 0;
+                int rtp_payload_type = 96;
+
+                byte rtp_byte_0 = (byte)((rtp_version << 6) | (rtp_padding << 5) | (rtp_extension << 4) | rtp_csrc_count);
+                byte rtp_byte_1 = (byte)((rtp_marker << 7) | (rtp_payload_type & 0x7F));
+
+                rtp_packet.Add(rtp_byte_0);
+                rtp_packet.Add(rtp_byte_1);
+
+                rtp_packet.Add((byte)((session.sequence_number >> 8) & 0xFF));
+                rtp_packet.Add((byte)((session.sequence_number >> 0) & 0xFF));
+
+                session.sequence_number++;
+
+                rtp_packet.Add((byte)((timestamp >> 24) & 0xFF));
+                rtp_packet.Add((byte)((timestamp >> 16) & 0xFF));
+                rtp_packet.Add((byte)((timestamp >> 8) & 0xFF));
+                rtp_packet.Add((byte)((timestamp >> 0) & 0xFF));
+            
+                rtp_packet.Add((byte)((session.ssrc >> 24) & 0xFF));
+                rtp_packet.Add((byte)((session.ssrc >> 16) & 0xFF));
+                rtp_packet.Add((byte)((session.ssrc >> 8) & 0xFF));
+                rtp_packet.Add((byte)((session.ssrc >> 0) & 0xFF));
+
+                // Now append the raw NAL
+                foreach (byte b in raw_nal) rtp_packet.Add(b);
+
+                // Send as RTP over RTSP
+                int video_channel = 0;
+                object state = new object();
+
+                try
+                {
+                    // send the whole NAL. With RTP over RTSP we do not need to Fragment the NAL (as we do with UDP packets or Multicast)
+                    session.listener.BeginSendData(video_channel, rtp_packet.ToArray(), new AsyncCallback(session.listener.EndSendData), state);
+                }
+                catch
+                {
+                    Console.WriteLine("Error writing to listener " + session.listener.RemoteAdress);
+                    // Todo - could clean up the RTSP Listener
+                }
+            }
+        }
+
+        public class RTPSession
+        {
+            public Rtsp.RtspListener listener = null;  // The RTSP client connection
+            public int sequence_number = 1;            // RTP packet sequence number used with this client connection
+            public String session_id = "";             // RTSP Session ID used with this client connection
+            public int ssrc = 1;                       // SSRC value used with this client connection
+            public bool play = false;                         // set to true when Session is in Play mode
+        }
+    }
+
+

--- a/RtspCameraExample/TestCard.cs
+++ b/RtspCameraExample/TestCard.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+// (c) Roger Hardiman 2016
+
+// This class uses a System Timer to generate a YUV image at regular intervals
+// The ReceivedYUVFrame event is fired for each new YUV image
+
+public class TestCard
+{
+
+    // Events that applications can receive
+    public event ReceivedYUVFrameHandler ReceivedYUVFrame;
+
+    // Delegated functions (essentially the function prototype)
+    public delegate void ReceivedYUVFrameHandler(uint timestamp, int width, int height, byte[] data);
+
+
+    // Local variables
+    private System.Timers.Timer frame_timer;
+    private Stopwatch stopwatch;
+    private byte[] yuv_frame = null;
+    private int x_position = 0;
+    private int y_position = 0;
+    private int width = 0;
+    private int height = 0;
+
+    // Constructor
+    public TestCard(int width, int height, int fps)
+    {
+        this.width = width;
+        this.height = height;
+
+        // YUV size
+        int y_size = width * height;
+        int u_size = (width >> 1) * (height >> 1);
+        int v_size = (width >> 1) * (height >> 1);
+        yuv_frame = new byte[y_size + u_size + v_size];
+
+        // Set all values to 127
+        for (int x = 0; x < yuv_frame.Length; x++)
+        {
+            yuv_frame[x] = 127;
+        }
+
+        stopwatch = new Stopwatch();
+        stopwatch.Start();
+
+        // Start timer. The Timer will generate a YUV frame on every 'tick'
+        int interval_ms = 1000 / fps;
+        frame_timer = new System.Timers.Timer();
+        frame_timer.Interval = interval_ms;
+        frame_timer.AutoReset = true; // restart timer after the time has elapsed
+        frame_timer.Elapsed += (object sender, System.Timers.ElapsedEventArgs e) =>
+        {
+            // send a keepalive message
+            Send_YUV_Frame();
+        };
+        frame_timer.Start();
+        
+    }
+
+    // Dispose
+    public void Disconnect()
+    {
+        // Stop the frame timer
+        frame_timer.Stop();
+        frame_timer.Dispose();
+    }
+
+
+    private void Send_YUV_Frame()
+    {
+
+        // Toggle the pixel value
+        byte pixel_value = yuv_frame[(y_position * width) + x_position];
+
+        // change brightness of pixel			
+        if (pixel_value > 128) pixel_value = 30;
+        else pixel_value = 230;
+
+        yuv_frame[(y_position * width) + x_position] = pixel_value;
+
+        // move the x and y position
+        x_position = x_position + 5;
+        if (x_position >= width)
+        {
+            x_position = 0;
+            y_position = y_position + 1;
+        }
+
+        if (y_position >= height)
+        {
+            y_position = 0;
+        }
+
+        // fire the Event
+        if (ReceivedYUVFrame != null)
+        {
+            ReceivedYUVFrame((uint)stopwatch.ElapsedMilliseconds, width, height, yuv_frame);
+        }
+    }
+
+}

--- a/RtspCameraExample/TinyH264Encoder.cs
+++ b/RtspCameraExample/TinyH264Encoder.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+// Tiny H264 Encoder
+// World's Smallest h.264 Encoder, by Ben Mesander.
+// https://cardinalpeak.com/blog/worlds-smallest-h-264-encoder/
+//
+// Ported to C# by Roger Hardiman www.rjh.org.uk
+
+// Input: YUV image that must be 128x96
+// Output: H264 NAL
+//
+// This is a very simple lossless H264 encoder. No compression is used and so the output NAL data is as
+// large as the input YUV data.
+// It is used for a quick example of H264 encoding in pure .Net without needing OS specific APIs
+// or cross compiled C libraries.
+//
+// The H264 SPS/PPS data includes the image size. As the SPS/PPS is hard coded in this example the YUV
+// image size must be 128 x 96
+
+public class TinyH264Encoder
+{
+
+    int width = 0;
+    int height = 0;
+    int uv_width = 0;
+    int uv_height = 0;
+    int y_size = 0;
+    int u_size = 0;
+    int v_size = 0;
+
+    byte[] sps = { 0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2 };
+    //byte[] sps_b = { 0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2 }; // Annex B
+    //byte[] sps32 = { 0x00, 0x00, 0x00, 0x07, 0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2 }; // 32 bit size
+
+    byte[] pps = { 0x68, 0xce, 0x38, 0x80 };
+    //byte[] pps_b = { 0x00, 0x00, 0x00, 0x01, 0x68, 0xce, 0x38, 0x80 }; // Annex B
+    //byte[] pps32 = { 0x00, 0x00, 0x00, 0x04, 0x68, 0xce, 0x38, 0x80 }; // 32 bit size
+
+    byte[] slice_header = { 0x05, 0x88, 0x84, 0x21, 0xa0 };
+    //byte[] slice_header_b = { 0x00, 0x00, 0x00, 0x01, 0x05, 0x88, 0x84, 0x21, 0xa0 };
+    //byte[] slice_header_32 = { 0x00, 0x00, 0x00, 0x00, 0x05, 0x88, 0x84, 0x21, 0xa0 }; // must replace size bytes
+    byte[] slice_end = { 0x80 };
+    byte[] macroblock_header = { 0x0d, 0x00 };
+
+    List<byte> nal = new List<byte>();
+
+    // Constuctor
+    public TinyH264Encoder()
+    {
+        this.width = 128;  // Hard coded size that is embedded in the SPS/PPS data
+        this.height = 96;  // Hard coded size that is embedded in the SPS/PPS data
+        this.uv_width = width >> 1;
+        this.uv_height = height >> 1;
+        this.y_size = width * height;
+        this.u_size = (width >> 1) * (height >> 1);
+        this.v_size = (width >> 1) * (height >> 1);
+    }
+
+    public byte[] GetRawSPS()
+    {
+        return sps.ToArray();
+    }
+
+    public byte[] GetRawPPS()
+    {
+        return pps.ToArray();
+    }
+
+    public byte[] CompressFrame(byte[] yuv_data)
+    {
+        // we can only do 128 x 96
+        if (width != 128) return null;
+        if (height != 96) return null;
+
+        // check size
+        if (yuv_data.Length < (y_size + u_size + v_size))
+        {
+            // the yuv image is too small.
+            return null;
+        }
+
+        nal.Clear();
+
+        // Slice Header
+        foreach (byte b in slice_header) nal.Add(b);
+
+        // Add each macro block
+        for (int i = 0; i < (height / 16); i++) {
+            for (int j = 0; j < (width / 16); j++) {
+                macroblock(i, j, yuv_data);
+            }
+        }
+
+        // Add slice end
+        foreach (byte b in slice_end) nal.Add(b);
+
+        byte[] nal_array = nal.ToArray();
+
+        return nal_array;
+    }
+
+    /* Write a macroblock's worth of YUV data in I_PCM mode */
+    private void macroblock(int i, int j, byte[] frame)
+    {
+        int x, y;
+
+        if (!((i == 0) && (j == 0)))
+        {
+            foreach (byte b in macroblock_header) nal.Add(b);
+        }
+
+        for (x = i * 16; x < ((i + 1) * 16); x++)
+        {
+            for (y = j * 16; y < ((j + 1) * 16); y++)
+            {
+                nal.Add(frame[(x * width) + y]);
+            }
+        }
+        for (x = i * 8; x < (i + 1) * 8; x++)
+        {
+            for (y = j * 8; y < (j + 1) * 8; y++)
+            {
+                nal.Add(frame[y_size + (x * uv_width) + y]);
+            }
+        }
+        for (x = i * 8; x < (i + 1) * 8; x++)
+        {
+            for (y = j * 8; y < (j + 1) * 8; y++)
+            {
+                nal.Add(frame[y_size + u_size + (x * uv_width) + y]);
+            }
+        }
+    }
+
+
+    public void ChangeAnnexBto32BitSize(byte[] data)
+    {
+
+        if (data.Length < 4) return;
+
+        // change data from 0x00 0x00 0x00 0x01 format to 32 bit size
+        int len = data.Length - 4;// subtract Annex B header size
+
+        if (BitConverter.IsLittleEndian)
+        {
+            data[0] = (byte)((len >> 24) & 0xFF);
+            data[1] = (byte)((len >> 16) & 0xFF);
+            data[2] = (byte)((len >> 8) & 0xFF);
+            data[3] = (byte)((len << 0) & 0xFF);
+        }
+        else
+        {
+            data[0] = (byte)((len >> 0) & 0xFF);
+            data[1] = (byte)((len >> 8) & 0xFF);
+            data[2] = (byte)((len >> 16) & 0xFF);
+            data[3] = (byte)((len >> 24) & 0xFF);
+        }
+    }
+}
+


### PR DESCRIPTION
This pull request adds an example RTSP Camera Server.
It generates a test YUV image, encodes it into H264 (using the Tiny H264 Encoder project which is a lossless encoder) and streams RTP over RTSP
(multicast and UDP are still to be added)

There are some places where code needs to be improved. Examples include
errors when writing to the TCP socket for RTP over RTSP should close the RTSP socket
Performing a PLAY or PAUSE on a Session ID that does not exist should return a RTSP error message (currently it it returns OK)
It only supports RTP over RTSP and so has no code to fragment large NALs which is needed for UDP and for Multicast
There is no UDP or Multicast support

The code is written as a foundation for taking NALs from a real camera and a real H264 encoder