### PR TITLE
RTSP library exception and changes to CameraExample

### DIFF
--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -443,7 +443,13 @@
         /// <param name="result">The result.</param>
         public void EndSendData(IAsyncResult result)
         {
-            _stream.EndWrite(result);
+            try
+            {
+                _stream.EndWrite(result);
+            } catch (Exception e)
+            { // Error, for example stream has already been Disposed
+                result = null;
+            }
         }
 
         #region IDisposable Membres

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -18,313 +18,317 @@ using System.Collections.Generic;
 // The Tiny H264 Encoder is a 100% .NET encoder which is lossless and creates large bitstreams as
 // there is no compression. It is limited to 128x96 resolution. However it makes it easy to write a quick
 // demo without needing native APIs or cross compiled C libraries for H264
-    
-    public class RtspServer : IDisposable
+
+public class RtspServer : IDisposable
+{
+
+    private TcpListener _RTSPServerListener;
+    private ManualResetEvent _Stopping;
+    private Thread _ListenTread;
+
+    private TestCard video_source = null;
+    private TinyH264Encoder h264_encoder = null;
+
+    List<RTPSession> rtp_list = new List<RTPSession>(); // list of RTSP Listeners, used when sending RTP over RTSP
+
+    Random rnd = new Random();
+    int session_count = 0;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RTSPServer"/> class.
+    /// </summary>
+    /// <param name="aPortNumber">A numero port.</param>
+    public RtspServer(int portNumber)
     {
+        if (portNumber < System.Net.IPEndPoint.MinPort || portNumber > System.Net.IPEndPoint.MaxPort)
+            throw new ArgumentOutOfRangeException("aPortNumber", portNumber, "Port number must be between System.Net.IPEndPoint.MinPort and System.Net.IPEndPoint.MaxPort");
+        Contract.EndContractBlock();
 
-        private TcpListener _RTSPServerListener;
-        private ManualResetEvent _Stopping;
-        private Thread _ListenTread;
+        RtspUtils.RegisterUri();
+        _RTSPServerListener = new TcpListener(IPAddress.Any, portNumber);
+    }
 
-        private TestCard video_source = null;
-        private TinyH264Encoder h264_encoder = null;
+    /// <summary>
+    /// Starts the listen.
+    /// </summary>
+    public void StartListen()
+    {
+        _RTSPServerListener.Start();
 
-        List<RTPSession> rtp_list = new List<RTPSession>(); // list of RTSP Listeners, used when sending RTP over RTSP
+        _Stopping = new ManualResetEvent(false);
+        _ListenTread = new Thread(new ThreadStart(AcceptConnection));
+        _ListenTread.Start();
 
-        Random rnd = new Random();
-        int session_count = 0;
+        // Initialise the H264 encoder
+        h264_encoder = new TinyH264Encoder();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RTSPServer"/> class.
-        /// </summary>
-        /// <param name="aPortNumber">A numero port.</param>
-        public RtspServer(int portNumber)
+        // Start the VideoSource
+        video_source = new TestCard(128, 96, 6);
+        video_source.ReceivedYUVFrame += video_source_ReceivedYUVFrame;
+    }
+
+
+    /// <summary>
+    /// Accepts the connection.
+    /// </summary>
+    private void AcceptConnection()
+    {
+        try
         {
-            if (portNumber < System.Net.IPEndPoint.MinPort || portNumber > System.Net.IPEndPoint.MaxPort)
-                throw new ArgumentOutOfRangeException("aPortNumber", portNumber, "Port number must be between System.Net.IPEndPoint.MinPort and System.Net.IPEndPoint.MaxPort");
-            Contract.EndContractBlock();
-
-            RtspUtils.RegisterUri();
-            _RTSPServerListener = new TcpListener(IPAddress.Any, portNumber);
+            while (!_Stopping.WaitOne(0))
+            {
+                TcpClient oneClient = _RTSPServerListener.AcceptTcpClient();
+                var rtsp_socket = new RtspTcpTransport(oneClient);
+                RtspListener newListener = new RtspListener(rtsp_socket);
+                newListener.MessageReceived += RTSP_Message_Received;
+                //RTSPDispatcher.Instance.AddListener(newListener);
+                newListener.Start();
+            }
         }
-
-        /// <summary>
-        /// Starts the listen.
-        /// </summary>
-        public void StartListen()
+        catch (SocketException error)
         {
-            _RTSPServerListener.Start();
-            
-            _Stopping = new ManualResetEvent(false);
-            _ListenTread = new Thread(new ThreadStart(AcceptConnection));
-            _ListenTread.Start();
-
-            // Initialise the H264 encoder
-            h264_encoder = new TinyH264Encoder();
-
-            // Start the VideoSource
-            video_source = new TestCard(128, 96, 6);
-            video_source.ReceivedYUVFrame += video_source_ReceivedYUVFrame;
+            // _logger.Warn("Got an error listening, I have to handle the stopping which also throw an error", error);
         }
-
-
-        /// <summary>
-        /// Accepts the connection.
-        /// </summary>
-        private void AcceptConnection()
+        catch (Exception error)
         {
-            try
-            {
-                while (!_Stopping.WaitOne(0))
-                {
-                    TcpClient oneClient = _RTSPServerListener.AcceptTcpClient();
-                    var rtsp_socket = new RtspTcpTransport(oneClient);
-                    RtspListener newListener = new RtspListener(rtsp_socket);
-                    newListener.MessageReceived += RTSP_Message_Received;
-                    //RTSPDispatcher.Instance.AddListener(newListener);
-                    newListener.Start();
-                }
-            }
-            catch (SocketException error)
-            {
-               // _logger.Warn("Got an error listening, I have to handle the stopping which also throw an error", error);
-            }
-            catch (Exception error)
-            {
-               // _logger.Error("Got an error listening...", error);
-                throw;
-            }
-
-
+            // _logger.Error("Got an error listening...", error);
+            throw;
         }
 
 
-        public void StopListen()
+    }
+
+
+    public void StopListen()
+    {
+        _RTSPServerListener.Stop();
+        _Stopping.Set();
+        _ListenTread.Join();
+    }
+
+    #region IDisposable Membres
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
         {
-            _RTSPServerListener.Stop();
-            _Stopping.Set();
-            _ListenTread.Join();
+            StopListen();
+            _Stopping.Dispose();
+        }
+    }
+
+    #endregion
+
+    // Process each RTSP message that is received
+    private void RTSP_Message_Received(object sender, RtspChunkEventArgs e)
+    {
+        // Cast the 'sender' and 'e' into the RTSP Listener (the Socket) and the RTSP Message
+        Rtsp.RtspListener listener = sender as Rtsp.RtspListener;
+        Rtsp.Messages.RtspMessage message = e.Message as Rtsp.Messages.RtspMessage;
+
+        Console.WriteLine("RTSP message received " + message);
+
+        // Handle OPTIONS message
+        if (message is Rtsp.Messages.RtspRequestOptions)
+        {
+            // Create the reponse to OPTIONS
+            Rtsp.Messages.RtspResponse options_response = (e.Message as Rtsp.Messages.RtspRequestOptions).CreateResponse();
+            listener.SendMessage(options_response);
         }
 
-        #region IDisposable Membres
-
-        public void Dispose()
+        // Handle DESCRIBE message
+        if (message is Rtsp.Messages.RtspRequestDescribe)
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            String requested_url = (message as Rtsp.Messages.RtspRequestDescribe).RtspUri.ToString();
+            Console.WriteLine("Request for " + requested_url);
+
+            // TODO. Check the requsted_url is valid. In this example we accept any RTSP URL
+
+            // Make the Base64 SPS and PPS
+            byte[] raw_sps = h264_encoder.GetRawSPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
+            byte[] raw_pps = h264_encoder.GetRawPPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
+            String sps_str = Convert.ToBase64String(raw_sps);
+            String pps_str = Convert.ToBase64String(raw_pps);
+
+            StringBuilder sdp = new StringBuilder();
+
+            // Generate the SDP
+            // The sprop-parameter-sets provide the SPS and PPS for H264 video
+            // The packetization-mode defines the H264 over RTP payloads used but is Optional
+            sdp.Append("v=0\n");
+            sdp.Append("o=user 123 0 IN IP4 0.0.0.0\n");
+            sdp.Append("s=SharpRTSP Test Camera\n");
+            sdp.Append("m=video 0 RTP/AVP 96\n");
+            sdp.Append("c=IN IP4 0.0.0.0\n");
+            sdp.Append("a=control:trackID=0\n");
+            sdp.Append("a=rtpmap:96 H264/90000\n");
+            sdp.Append("a=fmtp:96 profile-level-id=42A01E; sprop-parameter-sets=" + sps_str + "," + pps_str + ";\n");
+
+            byte[] sdp_bytes = Encoding.ASCII.GetBytes(sdp.ToString());
+
+            // Create the reponse to DESCRIBE
+            // This must include the Session Description Protocol (SDP)
+            Rtsp.Messages.RtspResponse describe_response = (e.Message as Rtsp.Messages.RtspRequestDescribe).CreateResponse();
+
+            describe_response.AddHeader("Content-Base: " + requested_url);
+            describe_response.AddHeader("Content-Type: application/sdp");
+            describe_response.Data = sdp_bytes;
+            describe_response.AdjustContentLength();
+            listener.SendMessage(describe_response);
         }
 
-        protected virtual void Dispose(bool disposing)
+        // Handle SETUP message
+        if (message is Rtsp.Messages.RtspRequestSetup)
         {
-            if (disposing)
+
+            // 
+            var setupMessage = message as Rtsp.Messages.RtspRequestSetup;
+
+            // Check the RTSP transport
+            // If it is UDP or Multicast, create the sockets
+            // If it is RTP over RTSP we send data via the RTSP Listener
+
+            // FIXME client may send more than one possible transport.
+            // very rare
+            Rtsp.Messages.RtspTransport transport = setupMessage.GetTransports()[0];
+
+
+            // Construct the Transport: reply from the Server to the client
+            Rtsp.Messages.RtspTransport transport_reply = new Rtsp.Messages.RtspTransport();
+
+            if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.TCP)
             {
-                StopListen();
-                _Stopping.Dispose();
-            }
-        }
-
-        #endregion
-
-        // Process each RTSP message that is received
-        private void RTSP_Message_Received(object sender, RtspChunkEventArgs e)
-        {
-            // Cast the 'sender' and 'e' into the RTSP Listener (the Socket) and the RTSP Message
-            Rtsp.RtspListener listener = sender as Rtsp.RtspListener;
-            Rtsp.Messages.RtspMessage message = e.Message as Rtsp.Messages.RtspMessage;
-
-            Console.WriteLine("RTSP message received " + message);
-
-            // Handle OPTIONS message
-            if (message is Rtsp.Messages.RtspRequestOptions)
-            {
-                // Create the reponse to OPTIONS
-                Rtsp.Messages.RtspResponse options_response = (e.Message as Rtsp.Messages.RtspRequestOptions).CreateResponse();
-                listener.SendMessage(options_response);
+                // RTP over RTSP mode}
+                transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.TCP;
+                transport_reply.Interleaved = new Rtsp.Messages.PortCouple(transport.Interleaved.First, transport.Interleaved.Second);
             }
 
-            // Handle DESCRIBE message
-            if (message is Rtsp.Messages.RtspRequestDescribe)
+            if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.UDP
+                && transport.IsMulticast == false)
             {
-                String requested_url = (message as Rtsp.Messages.RtspRequestDescribe).RtspUri.ToString();
-                Console.WriteLine("Request for " + requested_url);
-
-                // TODO. Check the requsted_url is valid. In this example we accept any RTSP URL
-
-                // Make the Base64 SPS and PPS
-                byte[] raw_sps = h264_encoder.GetRawSPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
-                byte[] raw_pps = h264_encoder.GetRawPPS(); // no 0x00 0x00 0x00 0x01 or 32 bit size header
-                String sps_str = Convert.ToBase64String(raw_sps);
-                String pps_str = Convert.ToBase64String(raw_pps);
-
-                StringBuilder sdp = new StringBuilder();
-
-                // Generate the SDP
-                // The sprop-parameter-sets provide the SPS and PPS for H264 video
-                // The packetization-mode defines the H264 over RTP payloads used but is Optional
-                sdp.Append("v=0\n");
-                sdp.Append("o=user 123 0 IN IP4 0.0.0.0\n");
-                sdp.Append("s=SharpRTSP Test Camera\n");
-                sdp.Append("m=video 0 RTP/AVP 96\n");
-                sdp.Append("c=IN IP4 0.0.0.0\n");
-                sdp.Append("a=control:trackID=0\n");
-                sdp.Append("a=rtpmap:96 H264/90000\n");
-                sdp.Append("a=fmtp:96 profile-level-id=42A01E; sprop-parameter-sets="+sps_str+","+pps_str+";\n");
-
-                byte[] sdp_bytes = Encoding.ASCII.GetBytes(sdp.ToString());
-
-                // Create the reponse to DESCRIBE
-                // This must include the Session Description Protocol (SDP)
-                Rtsp.Messages.RtspResponse describe_response = (e.Message as Rtsp.Messages.RtspRequestDescribe).CreateResponse();
-
-                describe_response.AddHeader("Content-Base: " + requested_url);
-                describe_response.AddHeader("Content-Type: application/sdp");
-                describe_response.Data = sdp_bytes;
-                describe_response.AdjustContentLength();
-                listener.SendMessage(describe_response);
+                // RTP over UDP mode}
+                // Create a pair of UDP sockets
+                // Pass the Port of the two sockets back in the reply
+                transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.UDP;
+                transport_reply.IsMulticast = false;
+                transport_reply.ClientPort = transport.ClientPort;  // FIX
+                                                                    // for now until implemented
+                transport_reply = null;
             }
 
-            // Handle SETUP message
-            if (message is Rtsp.Messages.RtspRequestSetup)
+            if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.UDP
+                && transport.IsMulticast == true)
             {
+                // RTP over Multicast UDP mode}
+                // Create a pair of UDP sockets in Multicast Mode
+                // Pass the Ports of the two sockets back in the reply
+                transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.UDP;
+                transport_reply.IsMulticast = true;
+                transport_reply.Port = new Rtsp.Messages.PortCouple(7000, 7001);  // FIX
 
-                // 
-                var setupMessage = message as Rtsp.Messages.RtspRequestSetup;
-                
-                // Check the RTSP transport
-                // If it is UDP or Multicast, create the sockets
-                // If it is RTP over RTSP we send data via the RTSP Listener
-                
-                // FIXME client may send more than one possible transport.
-                // very rare
-                Rtsp.Messages.RtspTransport transport = setupMessage.GetTransports()[0];
-                
-
-                // Construct the Transport: reply from the Server to the client
-                Rtsp.Messages.RtspTransport transport_reply = new Rtsp.Messages.RtspTransport();
-
-                if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.TCP) {
-                    // RTP over RTSP mode}
-                    transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.TCP;
-                    transport_reply.Interleaved = new Rtsp.Messages.PortCouple(transport.Interleaved.First,transport.Interleaved.Second);
-                }
-
-                if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.UDP
-                    && transport.IsMulticast == false) {
-                    // RTP over UDP mode}
-                    // Create a pair of UDP sockets
-                    // Pass the Port of the two sockets back in the reply
-                    transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.UDP;
-                    transport_reply.IsMulticast = false;
-                    transport_reply.ClientPort = transport.ClientPort;  // FIX
-                    // for now until implemented
-                    transport_reply = null;
-                }
-
-                if (transport.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.UDP
-                    && transport.IsMulticast == true) {
-                    // RTP over Multicast UDP mode}
-                    // Create a pair of UDP sockets in Multicast Mode
-                    // Pass the Ports of the two sockets back in the reply
-                    transport_reply.LowerTransport = Rtsp.Messages.RtspTransport.LowerTransportType.UDP;
-                    transport_reply.IsMulticast = true;
-                    transport_reply.Port = new Rtsp.Messages.PortCouple(7000,7001);  // FIX
-
-                    // for now until implemented
-                    transport_reply = null;
-                }
-
-
-                if (transport_reply != null)
-                {
-
-                    RTPSession new_session = new RTPSession();
-                    new_session.listener = listener;
-                    new_session.sequence_number = (UInt16)rnd.Next(65535); // start with a random 16 bit sequence number
-                    new_session.ssrc = 1;
-
-                    // Add the transports to the Session
-                    new_session.client_transport = transport;
-                    new_session.transport_reply = transport_reply;
-
-                    lock (rtp_list)
-                    {
-                        // Create a 'Session' and add it to the Session List
-                        // ToDo - Check the Track ID. In the SDP the H264 video track is TrackID 0
-                        // Place Lock() here so the Session Count and the addition to the list is locked
-                        new_session.session_id = session_count.ToString();
-
-                        // Add the new session to the Sessions List
-                        rtp_list.Add(new_session);
-                        session_count++;
-                    }
-
-
-                    Rtsp.Messages.RtspResponse setup_response = setupMessage.CreateResponse();
-                    setup_response.Headers[Rtsp.Messages.RtspHeaderNames.Transport] = transport_reply.ToString();
-                    setup_response.Session = new_session.session_id;
-                    listener.SendMessage(setup_response);
-                }
-                else
-                {
-                    Rtsp.Messages.RtspResponse setup_response = setupMessage.CreateResponse();
-                    // unsuported transport
-                    setup_response.ReturnCode =461;
-                    listener.SendMessage(setup_response);
-                }
-
+                // for now until implemented
+                transport_reply = null;
             }
 
-            // Handle PLAY message
-            if (message is Rtsp.Messages.RtspRequestPlay)
+
+            if (transport_reply != null)
             {
+
+                RTPSession new_session = new RTPSession();
+                new_session.listener = listener;
+                new_session.sequence_number = (UInt16)rnd.Next(65535); // start with a random 16 bit sequence number
+                new_session.ssrc = 1;
+
+                // Add the transports to the Session
+                new_session.client_transport = transport;
+                new_session.transport_reply = transport_reply;
+
                 lock (rtp_list)
                 {
-                    // Search for the Session in the Sessions List. Change the state of "PLAY"
-                    foreach (RTPSession session in rtp_list)
-                    {
-                        if (session.session_id.Equals(message.Session)) {
-                            // found the session
-                            session.play = true;
-                            break;
-                        }
-                    }
+                    // Create a 'Session' and add it to the Session List
+                    // ToDo - Check the Track ID. In the SDP the H264 video track is TrackID 0
+                    // Place Lock() here so the Session Count and the addition to the list is locked
+                    new_session.session_id = session_count.ToString();
+
+                    // Add the new session to the Sessions List
+                    rtp_list.Add(new_session);
+                    session_count++;
                 }
 
-                // ToDo - only send back the OK response if the Session in the RTSP message was found
-                Rtsp.Messages.RtspResponse play_response = (e.Message as Rtsp.Messages.RtspRequestPlay).CreateResponse();
-                listener.SendMessage(play_response);
+
+                Rtsp.Messages.RtspResponse setup_response = setupMessage.CreateResponse();
+                setup_response.Headers[Rtsp.Messages.RtspHeaderNames.Transport] = transport_reply.ToString();
+                setup_response.Session = new_session.session_id;
+                listener.SendMessage(setup_response);
+            }
+            else
+            {
+                Rtsp.Messages.RtspResponse setup_response = setupMessage.CreateResponse();
+                // unsuported transport
+                setup_response.ReturnCode = 461;
+                listener.SendMessage(setup_response);
             }
 
-            // Handle PLAUSE message
-            if (message is Rtsp.Messages.RtspRequestPause)
+        }
+
+        // Handle PLAY message
+        if (message is Rtsp.Messages.RtspRequestPlay)
+        {
+            lock (rtp_list)
             {
-                lock (rtp_list)
+                // Search for the Session in the Sessions List. Change the state of "PLAY"
+                foreach (RTPSession session in rtp_list)
                 {
-                    // Search for the Session in the Sessions List. Change the state of "PLAY" 
-                    foreach (RTPSession session in rtp_list)
+                    if (session.session_id.Equals(message.Session))
                     {
-                        if (session.session_id.Equals(message.Session))
-                        {
-                            // found the session
-                            session.play = false;
-                            break;
-                        }
+                        // found the session
+                        session.play = true;
+                        break;
                     }
                 }
-
-                // ToDo - only send back the OK response if the Session in the RTSP message was found
-                Rtsp.Messages.RtspResponse pause_response = (e.Message as Rtsp.Messages.RtspRequestPause).CreateResponse();
-                listener.SendMessage(pause_response);
             }
 
+            // ToDo - only send back the OK response if the Session in the RTSP message was found
+            Rtsp.Messages.RtspResponse play_response = (e.Message as Rtsp.Messages.RtspRequestPlay).CreateResponse();
+            listener.SendMessage(play_response);
+        }
 
-            // Handle GET_PARAMETER message, often used as a Keep Alive
-            if (message is Rtsp.Messages.RtspRequestGetParameter)
+        // Handle PLAUSE message
+        if (message is Rtsp.Messages.RtspRequestPause)
+        {
+            lock (rtp_list)
             {
-                // Create the reponse to GET_PARAMETER
-                Rtsp.Messages.RtspResponse getparameter_response = (e.Message as Rtsp.Messages.RtspRequestGetParameter).CreateResponse();
-                listener.SendMessage(getparameter_response);
+                // Search for the Session in the Sessions List. Change the state of "PLAY" 
+                foreach (RTPSession session in rtp_list)
+                {
+                    if (session.session_id.Equals(message.Session))
+                    {
+                        // found the session
+                        session.play = false;
+                        break;
+                    }
+                }
             }
+
+            // ToDo - only send back the OK response if the Session in the RTSP message was found
+            Rtsp.Messages.RtspResponse pause_response = (e.Message as Rtsp.Messages.RtspRequestPause).CreateResponse();
+            listener.SendMessage(pause_response);
+        }
+
+
+        // Handle GET_PARAMETER message, often used as a Keep Alive
+        if (message is Rtsp.Messages.RtspRequestGetParameter)
+        {
+            // Create the reponse to GET_PARAMETER
+            Rtsp.Messages.RtspResponse getparameter_response = (e.Message as Rtsp.Messages.RtspRequestGetParameter).CreateResponse();
+            listener.SendMessage(getparameter_response);
+        }
 
 
         // Handle TEARDOWN
@@ -350,132 +354,132 @@ using System.Collections.Generic;
 
     }
 
-        void video_source_ReceivedYUVFrame(uint timestamp_ms, int width, int height, byte[] yuv_data)
+    void video_source_ReceivedYUVFrame(uint timestamp_ms, int width, int height, byte[] yuv_data)
+    {
+
+        // Check if there are any clients. Only run the encoding if someone is connected
+        // Could exand this to check if someone is connected and in PLAY mode
+        int current_rtp_count = rtp_list.Count;
+
+        if (current_rtp_count == 0) return;
+
+        // Take the YUV image and encode it into a H264 NAL
+        // This returns a NAL with no headers (no 00 00 00 01 header and no 32 bit sizes)
+        Console.WriteLine("Compressing video at time(ms) " + timestamp_ms + "    " + current_rtp_count + " RTSP clients connected");
+        byte[] raw_nal = h264_encoder.CompressFrame(yuv_data);
+
+
+        // Build a RTP packet, but leave the sequence_number empty and the ssrc empty.
+        // They are different for each client so are added just before transmission.
+
+        int sequence_number_position = 0;
+        int ssrc_position = 0;
+
+        List<byte> rtp_packet = new List<byte>();
+
+        // RTP Packet Header
+        // 0 - Version, P, X, CC, M, PT and Sequence Number
+        //32 - Timestamp. H264 uses a 90kHz clock
+        //64 - SSRC
+        //96 - CSRCs (optional)
+        //nn - Extension ID and Length
+        //nn - Extension header
+
+        int rtp_version = 2;
+        int rtp_padding = 0;
+        int rtp_extension = 0;
+        int rtp_csrc_count = 0;
+        int rtp_marker = 0;
+        int rtp_payload_type = 96;
+
+        byte rtp_byte_0 = (byte)((rtp_version << 6) | (rtp_padding << 5) | (rtp_extension << 4) | rtp_csrc_count);
+        byte rtp_byte_1 = (byte)((rtp_marker << 7) | (rtp_payload_type & 0x7F));
+
+        rtp_packet.Add(rtp_byte_0);
+        rtp_packet.Add(rtp_byte_1);
+
+        sequence_number_position = rtp_packet.Count; // record the position. We populate the data later
+        UInt16 empty_sequence_number = 0;
+        rtp_packet.Add((byte)((empty_sequence_number >> 8) & 0xFF));
+        rtp_packet.Add((byte)((empty_sequence_number >> 0) & 0xFF));
+
+        UInt32 ts = timestamp_ms * 90; // 90kHZ clock
+
+        rtp_packet.Add((byte)((ts >> 24) & 0xFF));
+        rtp_packet.Add((byte)((ts >> 16) & 0xFF));
+        rtp_packet.Add((byte)((ts >> 8) & 0xFF));
+        rtp_packet.Add((byte)((ts >> 0) & 0xFF));
+
+        ssrc_position = rtp_packet.Count;
+        UInt32 empty_ssrc = 0;
+        rtp_packet.Add((byte)((empty_ssrc >> 24) & 0xFF));
+        rtp_packet.Add((byte)((empty_ssrc >> 16) & 0xFF));
+        rtp_packet.Add((byte)((empty_ssrc >> 8) & 0xFF));
+        rtp_packet.Add((byte)((empty_ssrc >> 0) & 0xFF));
+
+        // Now append the raw NAL
+        foreach (byte b in raw_nal) rtp_packet.Add(b);
+
+
+        lock (rtp_list)
         {
-
-            // Check if there are any clients. Only run the encoding if someone is connected
-            // Could exand this to check if someone is connected and in PLAY mode
-            int current_rtp_count = rtp_list.Count;
-
-            if (current_rtp_count == 0) return;
-
-            // Take the YUV image and encode it into a H264 NAL
-            // This returns a NAL with no headers (no 00 00 00 01 header and no 32 bit sizes)
-            Console.WriteLine("Compressing video at time(ms) " + timestamp_ms + "    " + current_rtp_count + " RTSP clients connected");
-            byte[] raw_nal = h264_encoder.CompressFrame(yuv_data);
-
-
-            // Build a RTP packet, but leave the sequence_number empty and the ssrc empty.
-            // They are different for each client so are added just before transmission.
-
-            int sequence_number_position = 0;
-            int ssrc_position = 0;
-
-            List<byte> rtp_packet = new List<byte>();
-
-            // RTP Packet Header
-            // 0 - Version, P, X, CC, M, PT and Sequence Number
-            //32 - Timestamp. H264 uses a 90kHz clock
-            //64 - SSRC
-            //96 - CSRCs (optional)
-            //nn - Extension ID and Length
-            //nn - Extension header
-
-            int rtp_version = 2;
-            int rtp_padding = 0;
-            int rtp_extension = 0;
-            int rtp_csrc_count = 0;
-            int rtp_marker = 0;
-            int rtp_payload_type = 96;
-
-            byte rtp_byte_0 = (byte)((rtp_version << 6) | (rtp_padding << 5) | (rtp_extension << 4) | rtp_csrc_count);
-            byte rtp_byte_1 = (byte)((rtp_marker << 7) | (rtp_payload_type & 0x7F));
-
-            rtp_packet.Add(rtp_byte_0);
-            rtp_packet.Add(rtp_byte_1);
-
-            sequence_number_position = rtp_packet.Count; // record the position. We populate the data later
-            UInt16 empty_sequence_number = 0;
-            rtp_packet.Add((byte)((empty_sequence_number >> 8) & 0xFF));
-            rtp_packet.Add((byte)((empty_sequence_number >> 0) & 0xFF));
-
-            UInt32 ts = timestamp_ms * 90; // 90kHZ clock
-
-            rtp_packet.Add((byte)((ts >> 24) & 0xFF));
-            rtp_packet.Add((byte)((ts >> 16) & 0xFF));
-            rtp_packet.Add((byte)((ts >> 8) & 0xFF));
-            rtp_packet.Add((byte)((ts >> 0) & 0xFF));
-
-            ssrc_position = rtp_packet.Count;
-            UInt32 empty_ssrc = 0;
-            rtp_packet.Add((byte)((empty_ssrc >> 24) & 0xFF));
-            rtp_packet.Add((byte)((empty_ssrc >> 16) & 0xFF));
-            rtp_packet.Add((byte)((empty_ssrc >> 8) & 0xFF));
-            rtp_packet.Add((byte)((empty_ssrc >> 0) & 0xFF));
-
-            // Now append the raw NAL
-            foreach (byte b in raw_nal) rtp_packet.Add(b);
-
-
-            lock (rtp_list)
+            // Go through each RTSP session and output the NAL
+            foreach (RTPSession session in rtp_list.ToArray()) // ToArray makes a temp copy of the list.
+                                                               // This lets us delete items in the foreach
             {
-                // Go through each RTSP session and output the NAL
-                foreach (RTPSession session in rtp_list.ToArray()) // ToArray makes a temp copy of the list.
-                                                                 // This lets us delete items in the foreach
+
+                // Only process Sessions in Play Mode
+                if (session.play == false) continue;
+
+
+                // Add the specific data for each transmission
+                rtp_packet[sequence_number_position] = ((byte)((session.sequence_number >> 8) & 0xFF));
+                rtp_packet[sequence_number_position + 1] = ((byte)((session.sequence_number >> 0) & 0xFF));
+                session.sequence_number++;
+
+                rtp_packet[ssrc_position] = ((byte)((empty_ssrc >> 24) & 0xFF));
+                rtp_packet[ssrc_position + 1] = ((byte)((empty_ssrc >> 16) & 0xFF));
+                rtp_packet[ssrc_position + 2] = ((byte)((empty_ssrc >> 8) & 0xFF));
+                rtp_packet[ssrc_position + 3] = ((byte)((empty_ssrc >> 0) & 0xFF));
+
+
+                // Send as RTP over RTSP
+
+                if (session.transport_reply.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.TCP)
                 {
-
-                    // Only process Sessions in Play Mode
-                    if (session.play == false) continue;
-
-
-                    // Add the specific data for each transmission
-                    rtp_packet[sequence_number_position] = ((byte)((session.sequence_number >> 8) & 0xFF));
-                    rtp_packet[sequence_number_position + 1] = ((byte)((session.sequence_number >> 0) & 0xFF));
-                    session.sequence_number++;
-
-                    rtp_packet[ssrc_position] = ((byte)((empty_ssrc >> 24) & 0xFF));
-                    rtp_packet[ssrc_position + 1] = ((byte)((empty_ssrc >> 16) & 0xFF));
-                    rtp_packet[ssrc_position + 2] = ((byte)((empty_ssrc >> 8) & 0xFF));
-                    rtp_packet[ssrc_position + 3] = ((byte)((empty_ssrc >> 0) & 0xFF));
-
-
-                    // Send as RTP over RTSP
-
-                    if (session.transport_reply.LowerTransport == Rtsp.Messages.RtspTransport.LowerTransportType.TCP)
+                    int video_channel = session.transport_reply.Interleaved.First; // second is for RTCP status messages)
+                    object state = new object();
+                    try
                     {
-                        int video_channel = session.transport_reply.Interleaved.First; // second is for RTCP status messages)
-                        object state = new object();
-                        try
-                        {
-                            // send the whole NAL. With RTP over RTSP we do not need to Fragment the NAL (as we do with UDP packets or Multicast)
-                            session.listener.BeginSendData(video_channel, rtp_packet.ToArray(), new AsyncCallback(session.listener.EndSendData), state);
-                        }
-                        catch
-                        {
-                            Console.WriteLine("Error writing to listener " + session.listener.RemoteAdress);
-                            session.play = false; // stop sending data
-                            session.listener.Dispose();
-                            rtp_list.Remove(session); // remove the session. It is dead
-                            Console.WriteLine(rtp_list.Count + " remaining sessions open");
-                        }
+                        // send the whole NAL. With RTP over RTSP we do not need to Fragment the NAL (as we do with UDP packets or Multicast)
+                        session.listener.BeginSendData(video_channel, rtp_packet.ToArray(), new AsyncCallback(session.listener.EndSendData), state);
                     }
-                    // TODO. Add UDP and Multicast
-
+                    catch
+                    {
+                        Console.WriteLine("Error writing to listener " + session.listener.RemoteAdress);
+                        session.play = false; // stop sending data
+                        session.listener.Dispose();
+                        rtp_list.Remove(session); // remove the session. It is dead
+                        Console.WriteLine(rtp_list.Count + " remaining sessions open");
+                    }
                 }
+                // TODO. Add UDP and Multicast
+
             }
         }
-
-        public class RTPSession
-        {
-            public Rtsp.RtspListener listener = null;  // The RTSP client connection
-            public UInt16 sequence_number = 1;         // 16 bit RTP packet sequence number used with this client connection
-            public String session_id = "";             // RTSP Session ID used with this client connection
-            public int ssrc = 1;                       // SSRC value used with this client connection
-            public bool play = false;                  // set to true when Session is in Play mode
-            public Rtsp.Messages.RtspTransport client_transport; // Transport: string from the client to the server
-            public Rtsp.Messages.RtspTransport transport_reply; // Transport: reply from the server to the client
-            
-        }
     }
+
+    public class RTPSession
+    {
+        public Rtsp.RtspListener listener = null;  // The RTSP client connection
+        public UInt16 sequence_number = 1;         // 16 bit RTP packet sequence number used with this client connection
+        public String session_id = "";             // RTSP Session ID used with this client connection
+        public int ssrc = 1;                       // SSRC value used with this client connection
+        public bool play = false;                  // set to true when Session is in Play mode
+        public Rtsp.Messages.RtspTransport client_transport; // Transport: string from the client to the server
+        public Rtsp.Messages.RtspTransport transport_reply; // Transport: reply from the server to the client
+
+    }
+}
 
 

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -326,7 +326,29 @@ using System.Collections.Generic;
                 listener.SendMessage(getparameter_response);
             }
 
+
+        // Handle TEARDOWN
+        if (message is Rtsp.Messages.RtspRequestTeardown)
+        {
+            lock (rtp_list)
+            {
+                // Search for the Session in the Sessions List.
+                foreach (RTPSession session in rtp_list.ToArray()) // Convert to ToArray so we can delete from the rtp_list
+                {
+                    if (session.session_id.Equals(message.Session))
+                    {
+                        // TODO - Close UDP or Multicast transport
+                        // For TCP there is no transport to close
+                        rtp_list.Remove(session);
+                        // Close the RTSP socket
+                        listener.Dispose();
+                    }
+                }
+            }
         }
+
+
+    }
 
         void video_source_ReceivedYUVFrame(uint timestamp_ms, int width, int height, byte[] yuv_data)
         {

--- a/RtspCameraExample/TestCard.cs
+++ b/RtspCameraExample/TestCard.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -21,18 +22,39 @@ public class TestCard
 
     // Local variables
     private System.Timers.Timer frame_timer;
+    private int fps = 0;
     private Stopwatch stopwatch;
     private byte[] yuv_frame = null;
     private int x_position = 0;
     private int y_position = 0;
     private int width = 0;
     private int height = 0;
+    private Object generate_lock = new Object();
+
+    // ASCII Font
+    // Created by Roger Hardiman using an online generation tool
+    // http://www.riyas.org/2013/12/online-led-matrix-font-generator-with.html
+
+    byte[] ascii_0 = { 0x00, 0x3c, 0x42, 0x42, 0x42, 0x42, 0x42, 0x3c };
+    byte[] ascii_1 = { 0x00, 0x08, 0x18, 0x28, 0x08, 0x08, 0x08, 0x3e };
+    byte[] ascii_2 = { 0x00, 0x3e, 0x42, 0x02, 0x0c, 0x30, 0x40, 0x7e };
+    byte[] ascii_3 = { 0x00, 0x7c, 0x02, 0x02, 0x3c, 0x02, 0x02, 0x7c };
+    byte[] ascii_4 = { 0x00, 0x0c, 0x14, 0x24, 0x44, 0x7e, 0x04, 0x04 };
+    byte[] ascii_5 = { 0x00, 0x7e, 0x40, 0x40, 0x7c, 0x02, 0x02, 0x7c };
+    byte[] ascii_6 = { 0x00, 0x3e, 0x40, 0x40, 0x7c, 0x42, 0x42, 0x3c };
+    byte[] ascii_7 = { 0x00, 0x7e, 0x02, 0x02, 0x04, 0x08, 0x10, 0x20 };
+    byte[] ascii_8 = { 0x00, 0x3c, 0x42, 0x42, 0x3c, 0x42, 0x42, 0x3c };
+    byte[] ascii_9 = { 0x00, 0x3c, 0x42, 0x42, 0x3c, 0x02, 0x02, 0x3e };
+    byte[] ascii_colon = { 0x00, 0x00, 0x18, 0x18, 0x00, 0x18, 0x18, 0x00 };
+    byte[] ascii_space = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+    byte[] ascii_dot = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x18, 0x00 };
 
     // Constructor
     public TestCard(int width, int height, int fps)
     {
         this.width = width;
         this.height = height;
+        this.fps = fps;
 
         // YUV size
         int y_size = width * height;
@@ -74,33 +96,104 @@ public class TestCard
 
     private void Send_YUV_Frame()
     {
-
-        // Toggle the pixel value
-        byte pixel_value = yuv_frame[(y_position * width) + x_position];
-
-        // change brightness of pixel			
-        if (pixel_value > 128) pixel_value = 30;
-        else pixel_value = 230;
-
-        yuv_frame[(y_position * width) + x_position] = pixel_value;
-
-        // move the x and y position
-        x_position = x_position + 5;
-        if (x_position >= width)
+        lock (generate_lock)
         {
-            x_position = 0;
-            y_position = y_position + 1;
-        }
+            // Get the current time
+            DateTime now_utc = DateTime.UtcNow;
+            DateTime now_local = now_utc.ToLocalTime();
 
-        if (y_position >= height)
-        {
-            y_position = 0;
-        }
 
-        // fire the Event
-        if (ReceivedYUVFrame != null)
-        {
-            ReceivedYUVFrame((uint)stopwatch.ElapsedMilliseconds, width, height, yuv_frame);
+            long timestamp_ms = ((long)(now_utc.Ticks / TimeSpan.TicksPerMillisecond));
+
+            // Generate the String to write
+            char[] overlay = null;
+
+            if (width >= 96)
+            {
+                // Need 12 characters of 8x8 pixels. 12*8 = 96
+                // HH:MM:SS.mmm
+                String overlay_str = now_local.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture); // do not replace : or . by local formats
+                overlay = overlay_str.ToCharArray();
+            }
+            else
+            {
+                // Min for most video formats is 16x16, enough for 2 characters
+                String overlay_str = now_local.ToString("ss", CultureInfo.InvariantCulture); // do not replace : or . by local formats
+                overlay = overlay_str.ToCharArray();
+            }
+
+            // process each character
+            int start_row = ((height / 2) - 4); // start 4 pixels above the centre row (4 is half the font height)
+            for (int c = 0; c < overlay.Length; c++)
+            {
+                byte[] font = ascii_space;
+                if (overlay[c] == '0') font = ascii_0;
+                if (overlay[c] == '1') font = ascii_1;
+                if (overlay[c] == '2') font = ascii_2;
+                if (overlay[c] == '3') font = ascii_3;
+                if (overlay[c] == '4') font = ascii_4;
+                if (overlay[c] == '5') font = ascii_5;
+                if (overlay[c] == '6') font = ascii_6;
+                if (overlay[c] == '7') font = ascii_7;
+                if (overlay[c] == '8') font = ascii_8;
+                if (overlay[c] == '9') font = ascii_9;
+                if (overlay[c] == ' ') font = ascii_space;
+                if (overlay[c] == ':') font = ascii_colon;
+                if (overlay[c] == '.') font = ascii_dot;
+
+                // process the font character
+                for (int rows = 0; rows < 8; rows++)
+                {
+                    int y_plane_pos = (start_row * width) + (rows * width) + (c * 8);
+                    byte row_byte = font[rows];
+                    // bit shift the row byte into individual pixels where the font On/Off maps to Y intensity 50 or 200
+                    for (int bits = 0; bits < 8; bits++)
+                    {
+                        if ((row_byte & 0x80) == 0x80)
+                        {
+                            // Pixel On
+                            yuv_frame[y_plane_pos] = 200;
+                        }
+                        else
+                        {
+                            yuv_frame[y_plane_pos] = 50;
+                        }
+                        y_plane_pos++;
+                        row_byte = (byte)(row_byte << 1); // shift up so the next 'bit' to process is the most significant bit
+                    }
+                }
+            }
+
+
+
+
+            // Toggle the pixel value
+            byte pixel_value = yuv_frame[(y_position * width) + x_position];
+
+            // change brightness of pixel			
+            if (pixel_value > 128) pixel_value = 30;
+            else pixel_value = 230;
+
+            yuv_frame[(y_position * width) + x_position] = pixel_value;
+
+            // move the x and y position
+            x_position = x_position + 5;
+            if (x_position >= width)
+            {
+                x_position = 0;
+                y_position = y_position + 1;
+            }
+
+            if (y_position >= height)
+            {
+                y_position = 0;
+            }
+
+            // fire the Event
+            if (ReceivedYUVFrame != null)
+            {
+                ReceivedYUVFrame((uint)stopwatch.ElapsedMilliseconds, width, height, yuv_frame);
+            }
         }
     }
 


### PR DESCRIPTION
Hi
I have made some updates to the RTSP Camera example.
But I have also fixed one issue in the base RTSP library as well.

RTSP Library Change
The current code has a BeginWrite() and an EndWrite(). On Win10 I would get an exception on the EndWrite if the stream had already been disposed (eg the client had closed the socket).
Add a try/catch around the EndWrite.

RTSPCameraExample
Improvements. Updates the TestCard to include the current time HH:MM:SS.fff so latency can be seen.
Internal changes. Generate the RTP packet once and ajust the SSRC and Sequence Number prior to sending. Will reduce CPU usage. Only call H264 encoder when there are clients connected (reduces CPU usage)
Fixes. Lock the list of RTSP clients when processing the list.

Note - I see you had started a branch to split this example into smaller classes. I would like to do this in the example but have not had time yet.