### PR TITLE
fix parsing of fmtp config in cases where sampling freq is specified directly

### DIFF
--- a/RTSP/Rtp/AACPayload.cs
+++ b/RTSP/Rtp/AACPayload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Rtsp.Rtp
@@ -80,7 +80,7 @@ namespace Rtsp.Rtp
             var bits: AOT Specific Config
              ***/
 
-            // config is a string in hex eg 1490 or 0x1210
+            // config is a string in hex eg 1490 or 1210
             // Read each ASCII character and add to a bit array
             BitStream bs = new();
             bs.AddHexString(config_string);

--- a/RTSP/Rtp/AACPayload.cs
+++ b/RTSP/Rtp/AACPayload.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Rtsp.Rtp
@@ -64,6 +64,7 @@ namespace Rtsp.Rtp
     {
         public int ObjectType { get; set; } = 0;
         public int FrequencyIndex { get; set; } = 0;
+        public int SamplingFrequency { get; set; } = 0;
         public int ChannelConfiguration { get; set; } = 0;
 
         // Constructor
@@ -91,6 +92,12 @@ namespace Rtsp.Rtp
             // Read 4 bits
             FrequencyIndex = bs.Read(4);
 
+            if (FrequencyIndex == 15)
+            {
+                // the Sampling Frequency is specified directly
+                SamplingFrequency = bs.Read(24);
+            }
+
             // Read 4 bits
             ChannelConfiguration = bs.Read(4);
         }
@@ -115,8 +122,6 @@ namespace Rtsp.Rtp
             {
                 if (position + 4 > packet.PayloadSize) break; // 2 bytes for AU Header Length, 2 bytes of AU Header payload
 
-
-
                 // Get Size of the AU Header
                 int au_headers_length_bits = (rtp_payload[position] << 8) + (rtp_payload[position + 1] << 0); // 16 bits
                 int au_headers_length = (int)Math.Ceiling(au_headers_length_bits / 8.0);
@@ -136,7 +141,5 @@ namespace Rtsp.Rtp
 
             return audio_data;
         }
-
-
     }
 }


### PR DESCRIPTION
ISO 14496-1 1.6.2.1 allows for the sampling frequency to be directly specified as a 24 bit integer. Without this fix, the ChannelConfiguration would be incorrectly read in these cases.

I'm not sure how you might want to rework the `Received_AAC_Delegate` since it currently passes only the index, so I've left this alone just to ensure that at least the ChannelConfiguration will remain correct.