### PR TITLE
Reading error in RTSPListener

### DIFF
--- a/RTSP.Tests/RTSP.Tests.csproj
+++ b/RTSP.Tests/RTSP.Tests.csproj
@@ -9,6 +9,7 @@
 	  <None Remove="Rtp\Data\jpeg_0.rtp" />
 	  <None Remove="Rtp\Data\jpeg_1.rtp" />
 	  <None Remove="Rtp\Data\jpeg_2.rtp" />
+	  <None Remove="Sdp\Data\test4.sdp" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -24,6 +25,7 @@
 		<EmbeddedResource Include="Sdp\Data\test1.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test2.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test3.sdp" />
+		<EmbeddedResource Include="Sdp\Data\test4.sdp" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\RTSP\RTSP.csproj" />

--- a/RTSP.Tests/Sdp/Data/test4.sdp
+++ b/RTSP.Tests/Sdp/Data/test4.sdp
@@ -1,0 +1,20 @@
+v=0
+o=- 1707291593123122 1 IN IP4 192.168.3.80
+s=profile1
+u=http:///
+e=admin@
+t=0 0
+a=control:*
+a=range:npt=00.000- 
+m=video 0 RTP/AVP 96
+b=AS:5000
+a=control:track1
+a=rtpmap:96 H264/90000
+a=recvonly
+a=fmtp:96 profile-level-id=676400; sprop-parameter-sets=Z2QAKqwsaoHgCJ+WbgICAgQ=","aO4xshs=; packetization-mode=1
+m=audio 0 RTP/AVP 8
+b=AS:1000
+a=control:track2
+a=rtpmap:8 pcma/8000
+a=ptime:40
+a=recvonly

--- a/RTSP.Tests/Sdp/SdpFileTest.cs
+++ b/RTSP.Tests/Sdp/SdpFileTest.cs
@@ -81,5 +81,30 @@ namespace Rtsp.Sdp.Tests
             // Check the reader have read everything
             Assert.That(testReader.ReadToEnd(), Is.EqualTo(string.Empty));
         }
+
+        [Test]
+        public void Read4()
+        {
+            using var sdpFile = selfAssembly.GetManifestResourceStream("RTSP.Tests.Sdp.Data.test4.sdp");
+            using var testReader = new StreamReader(sdpFile);
+            SdpFile readenSDP = SdpFile.Read(testReader);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(readenSDP.Version, Is.EqualTo(0));
+                Assert.That(readenSDP.Origin.Username, Is.EqualTo("-"));
+                Assert.That(readenSDP.Origin.SessionId, Is.EqualTo("1707291593123122"));
+                Assert.That(readenSDP.Origin.SessionVersion, Is.EqualTo("1"));
+                Assert.That(readenSDP.Origin.NetType, Is.EqualTo("IN"));
+                Assert.That(readenSDP.Origin.AddressType, Is.EqualTo("IP4"));
+                Assert.That(readenSDP.Origin.UnicastAddress, Is.EqualTo("192.168.3.80"));
+                Assert.That(readenSDP.Session, Is.EqualTo("profile1"));
+                Assert.That(readenSDP.Url, Is.Null);
+                Assert.That(readenSDP.Email, Is.EqualTo("admin@"));
+
+                Assert.That(readenSDP.Attributs, Has.Count.EqualTo(2));
+                Assert.That(readenSDP.Medias, Has.Count.EqualTo(2));
+            });
+        }
     }
 }

--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -366,7 +366,7 @@
                         if (!currentMessage.Data.IsEmpty)
                         {
                             // Read the remaning data
-                            int byteCount = await commandStream.ReadAsync(currentMessage.Data, token).ConfigureAwait(false);
+                            int byteCount = await commandStream.ReadAsync(currentMessage.Data[byteReaden..], token).ConfigureAwait(false);
                             if (byteCount <= 0)
                             {
                                 currentReadingState = ReadingState.End;
@@ -408,7 +408,7 @@
                     case ReadingState.MoreInterleavedData when currentMessage is not null:
                         // apparently non blocking
                         {
-                            int byteCount = await commandStream.ReadAsync(currentMessage.Data, token).ConfigureAwait(false);
+                            int byteCount = await commandStream.ReadAsync(currentMessage.Data[byteReaden..], token).ConfigureAwait(false);
                             if (byteCount <= 0)
                             {
                                 currentReadingState = ReadingState.End;

--- a/RTSP/Sdp/SdpFile.cs
+++ b/RTSP/Sdp/SdpFile.cs
@@ -85,10 +85,13 @@ namespace Rtsp.Sdp
             {
                 try
                 {
-                    returnValue.Url = new Uri(value.Value);
-                    value = GetKeyValue(sdpStream);
+                    returnValue.Url = new Uri(value.Value);                    
                 }
                 catch {/* skip if cannot parse, some cams returns empty values for optional ones... */  }
+                finally
+                {
+                    value = GetKeyValue(sdpStream);
+                }
             }
 
             // Email optional

--- a/RTSP/Sdp/SdpFile.cs
+++ b/RTSP/Sdp/SdpFile.cs
@@ -83,8 +83,12 @@ namespace Rtsp.Sdp
             // Uri optional
             if (value.Key == "u")
             {
-                returnValue.Url = new Uri(value.Value);
-                value = GetKeyValue(sdpStream);
+                try
+                {
+                    returnValue.Url = new Uri(value.Value);
+                    value = GetKeyValue(sdpStream);
+                }
+                catch {/* skip if cannot parse, some cams returns empty values for optional ones... */  }
             }
 
             // Email optional


### PR DESCRIPTION
I have found a bug in the RTSP Listener class. (caused by my last pull request, sorry).

Reading without slicing the memory, will provide incorrect results... 
I have also added a check for -u in spdfile class. some cameras (chinese mostly) returns an empty url value, breaking the program and causing an Url Parsing exception