### PR TITLE
Rtsp playback

### DIFF
--- a/RTSP/Messages/RTSPRequestPlayback.cs
+++ b/RTSP/Messages/RTSPRequestPlayback.cs
@@ -17,7 +17,7 @@ public class RTSPRequestPlayback : RtspRequestPlay
     {
         if(seekTimeFrom> seekTimeTo) { throw new ArgumentException("seekTimeFrom cannot be after seekTimeTo", nameof(seekTimeFrom)); }
 
-        Headers.Add("range", FormattableString.Invariant($"clock={seekTimeFrom:yyyyMMdd}T{seekTimeFrom:HHmmss}-{seekTimeTo:yyyyMMdd}T{seekTimeTo:HHmmss}-"));
+        Headers.Add("range", FormattableString.Invariant($"clock={seekTimeFrom:yyyyMMdd}T{seekTimeFrom:HHmmss}-{seekTimeTo:yyyyMMdd}T{seekTimeTo:HHmmss}"));
         Headers.Add("scale", FormattableString.Invariant($"{scale}"));
     }
 }

--- a/RTSP/Messages/RTSPRequestPlayback.cs
+++ b/RTSP/Messages/RTSPRequestPlayback.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Rtsp.Messages;
+public class RTSPRequestPlayback : RtspRequestPlay
+{
+    /// <summary>
+    /// Instantiate a new Request play with range and scale headers
+    /// </summary>
+    /// <param name="seekTime">The seek time to start from</param>
+    /// <param name="scale">The "direction" of playback, < -1.0 for reverse playback</param>
+    public RTSPRequestPlayback(DateTime seekTime, double scale = 1.0) : base()
+    {
+        Headers.Add("range", FormattableString.Invariant($"clock={seekTime:yyyyMMdd}T{seekTime:HHmmss}-"));
+        Headers.Add("scale", FormattableString.Invariant($"{scale}"));
+    }
+    public RTSPRequestPlayback(DateTime seekTimeFrom, DateTime seekTimeTo, double scale = 1.0) : base()
+    {
+        if(seekTimeFrom> seekTimeTo) { throw new ArgumentException("seekTimeFrom cannot be after seekTimeTo", nameof(seekTimeFrom)); }
+
+        Headers.Add("range", FormattableString.Invariant($"clock={seekTimeFrom:yyyyMMdd}T{seekTimeFrom:HHmmss}-{seekTimeTo:yyyyMMdd}T{seekTimeTo:HHmmss}-"));
+        Headers.Add("scale", FormattableString.Invariant($"{scale}"));
+    }
+}


### PR DESCRIPTION
Added a basilar RTSP playback.
This is requested to camera (that supports it), with 2 headers, a range and an optional scale (for reverse playback).
There is no much to check/test for it, I am testing this at works with the onvif profile, cannot find too much camera details for the producer rtsp playback url.
onvif playback can be found under the [ProfileG](https://www.onvif.org/profiles/profile-g/) specification that provides an uri like this:
rtsp://<DeviceIP>ProfileG/<RecordingID>/recording/play.smp
the recordingID is provided by the ReplayPortClient.GetReplayUriAsync [replay.wsdl](https://www.onvif.org/ver10/replay.wsdl) with the token provided by RecordingPortClient.GetRecordingsAsync [recording.wsdl](https://www.onvif.org/ver10/recording.wsdl) (and yes, onvif protocol is a total  💩 )