### PR TITLE
Added extension for playback message

### DIFF
--- a/RTSP/Messages/RTSPHeaderNames.cs
+++ b/RTSP/Messages/RTSPHeaderNames.cs
@@ -15,5 +15,8 @@
 
         public const string WWWAuthenticate = "WWW-Authenticate";
         public const string Authorization = "Authorization";
+
+        public const string Range = "range";
+        public const string Scale = "scale";
     }
 }

--- a/RTSP/Onvif/RtspMessageOnvifExtension.cs
+++ b/RTSP/Onvif/RtspMessageOnvifExtension.cs
@@ -1,0 +1,21 @@
+﻿using Rtsp.Messages;
+using System;
+
+namespace Rtsp.Onvif
+{
+    public static class RtspMessageOnvifExtension
+    {
+        public static void AddPlayback(this RtspRequestPlay message, DateTime seekTime, double scale = 1.0)
+        {
+            message.Headers.Add(RtspHeaderNames.Scale, FormattableString.Invariant($"{scale:0.0}"));
+            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTime:o}-");
+        }
+        public static void AddPlayback(this RtspRequestPlay message, DateTime seekTimeFrom, DateTime seekTimeTo, double scale = 1.0)
+        {
+            message.Headers.Add(RtspHeaderNames.Scale, FormattableString.Invariant($"{scale:0.0}"));
+            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTimeFrom:o}-{seekTimeTo:o}");
+        }
+
+        // Here we can add other methods to add header like Require: onvif-replay
+    }
+}

--- a/RtspClientExample/Program.cs
+++ b/RtspClientExample/Program.cs
@@ -29,6 +29,7 @@ namespace RtspClientExample
 
             // string url = "http://192.168.3.72/profile1/media.smp";
 
+            bool usePlayback = false;
             string url = "rtsp://192.168.3.72/ProfileG/Recording-1/recording/play.smp";
 
             string username = "admin";
@@ -189,11 +190,11 @@ namespace RtspClientExample
 
                 foreach (var data in args.Data)
                 {
-                    string filename = Path.Combine("rtsp_capture_" + now ,  indexImg++ + ".jpg");
+                    string filename = Path.Combine("rtsp_capture_" + now, indexImg++ + ".jpg");
                     using var fs = new FileStream(filename, FileMode.Create);
                     fs.Write(data.Span);
                 }
-                
+
             };
 
             client.ReceivedG711 += (_, args) =>
@@ -286,10 +287,18 @@ namespace RtspClientExample
                 }
             };
 
-            client.SetupMessageCompleted += (_, _) => 
+            client.SetupMessageCompleted += (_, _) =>
             {
-                DateTime startTime = new DateTime(2024, 2, 22, 5, 10, 20);
-                client.Play(startTime, startTime.AddMinutes(10), 1.0);
+                if (usePlayback)
+                {
+                    // for demonstration play one hour in past
+                    DateTime startTime = DateTime.Now.AddHours(-1);
+                    client.Play(startTime, startTime.AddMinutes(10), 1.0);
+                }
+                else
+                {
+                    client.Play();
+                }
             };
 
             // Connect to RTSP Server

--- a/RtspClientExample/Program.cs
+++ b/RtspClientExample/Program.cs
@@ -28,6 +28,9 @@ namespace RtspClientExample
             //string url = "rtsp://192.168.0.89/media/video1";
 
             // string url = "http://192.168.3.72/profile1/media.smp";
+
+            string url = "rtsp://192.168.3.72/ProfileG/Recording-1/recording/play.smp";
+
             string username = "admin";
             string password = "Admin123!";
             // Axis Tests
@@ -56,7 +59,7 @@ namespace RtspClientExample
             //String url = "rtsp://127.0.0.1:8554/test";
 
             // Happytime RTSP Server
-            string url = "rtsp://127.0.0.1/screenlive";
+            //string url = "rtsp://127.0.0.1/screenlive";
 
 
 
@@ -283,10 +286,20 @@ namespace RtspClientExample
                 }
             };
 
+            client.SetupMessageCompleted += (_, _) => 
+            {
+                DateTime startTime = new DateTime(2024, 2, 22, 5, 10, 20);
+                client.Play(startTime, startTime.AddMinutes(10), 1.0);
+            };
+
             // Connect to RTSP Server
             Console.WriteLine("Connecting");
 
             client.Connect(url, username, password, RTSPClient.RTP_TRANSPORT.TCP, RTSPClient.MEDIA_REQUEST.VIDEO_AND_AUDIO);
+
+            //client.Pause();
+            //DateTime startTime = DateTime.Now.AddHours(-1);
+            //client.Play(startTime, startTime.AddMinutes(1), 1.0);
 
             // Wait for user to terminate programme
             // Check for null which is returned when running under some IDEs

--- a/RtspClientExample/Program.cs
+++ b/RtspClientExample/Program.cs
@@ -292,7 +292,7 @@ namespace RtspClientExample
                 if (usePlayback)
                 {
                     // for demonstration play one hour in past
-                    DateTime startTime = DateTime.Now.AddHours(-1);
+                    DateTime startTime = DateTime.UtcNow.AddHours(-1);
                     client.Play(startTime, startTime.AddMinutes(10), 1.0);
                 }
                 else

--- a/RtspClientExample/RTSPClient.cs
+++ b/RtspClientExample/RTSPClient.cs
@@ -66,6 +66,13 @@ namespace RtspClientExample
         // setup messages still to send
         readonly Queue<RtspRequestSetup> setupMessages = new();
 
+
+        /// <summary>
+        /// Called when the Setup command are completed, so we can start the right Play message (with or without playback informations)
+        /// </summary>
+        public event EventHandler? SetupMessageCompleted;
+
+
         // Constructor
         public RTSPClient(ILoggerFactory loggerFactory)
         {
@@ -218,9 +225,50 @@ namespace RtspClientExample
                 Session = session
             };
             play_message.AddAuthorization(_authentication, _uri, rtspSocket.NextCommandIndex());
+
+            //// Need for old sony camera SNC-CS20
+            play_message.Headers.Add("range", "npt=0.000-");
+
             rtspClient?.SendMessage(play_message);
         }
 
+        /// <summary>
+        /// Generate a Play request from required time
+        /// </summary>
+        /// <param name="seekTime">The playback time to start from</param>
+        /// <param name="speed">Speed information (1.0 means normal speed, -1.0 backward speed), other values >1.0 and <-1.0 allow a different speed</param>
+        public void Play(DateTime seekTime, double speed = 1.0)
+        {
+            if (rtspSocket is null || _uri is null) { throw new InvalidOperationException("Not connected"); }
+            RtspRequest playMessage = new RtspRequestPlay
+            {
+                RtspUri = _uri,
+                Session = session,
+            };
+            playMessage.AddPlayback(seekTime, speed);
+            rtspClient?.SendMessage(playMessage);
+        }
+
+        /// <summary>
+        /// Generate a Play request with a time range
+        /// </summary>
+        /// <param name="seekTimeFrom">Starting time for playback</param>
+        /// <param name="seekTimeTo">Ending time for playback</param>
+        /// <param name="speed">Speed information (1.0 means normal speed, -1.0 backward speed), other values >1.0 and <-1.0 allow a different speed</param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void Play(DateTime seekTimeFrom, DateTime seekTimeTo, double speed = 1.0)
+        {
+            if (rtspSocket is null || _uri is null) { throw new InvalidOperationException("Not connected"); }
+            if (seekTimeFrom > seekTimeTo) { throw new ArgumentOutOfRangeException(nameof(seekTimeFrom), "Starting seek cannot be major than ending seek."); }
+            RtspRequest playMessage = new RtspRequestPlay
+            {
+                RtspUri = _uri,
+                Session = session,
+            };
+
+            playMessage.AddPlayback(seekTimeFrom, seekTimeTo, speed);
+            rtspClient?.SendMessage(playMessage);
+        }
 
         public void Stop()
         {
@@ -739,18 +787,21 @@ namespace RtspClientExample
                 }
                 else
                 {
-                    // Send PLAY
-                    RtspRequest play_message = new RtspRequestPlay
-                    {
-                        RtspUri = _uri,
-                        Session = session
-                    };
+                    // use the event for setup completed, so the main program can call the Play command with or without the playback request.
+                    SetupMessageCompleted?.Invoke(this, EventArgs.Empty);
 
-                    // Need for old sony camera SNC-CS20
-                    play_message.Headers.Add("range", "npt=0.000-");
-
-                    play_message.AddAuthorization(_authentication, _uri!, rtspSocket!.NextCommandIndex());
-                    rtspClient?.SendMessage(play_message);
+                    //// Send PLAY
+                    //RtspRequest play_message = new RtspRequestPlay
+                    //{
+                    //    RtspUri = _uri,
+                    //    Session = session
+                    //};
+                    //
+                    //// Need for old sony camera SNC-CS20
+                    //play_message.Headers.Add("range", "npt=0.000-");
+                    //
+                    //play_message.AddAuthorization(_authentication, _uri!, rtspSocket!.NextCommandIndex());
+                    //rtspClient?.SendMessage(play_message);
                 }
             }
 

--- a/RtspClientExample/RTSPClient.cs
+++ b/RtspClientExample/RTSPClient.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Rtsp;
 using Rtsp.Messages;
+using Rtsp.Onvif;
 using Rtsp.Rtp;
 using Rtsp.Sdp;
 using System;
@@ -219,7 +220,7 @@ namespace RtspClientExample
             }
 
             // Send PLAY
-            RtspRequest play_message = new RtspRequestPlay
+            var play_message = new RtspRequestPlay
             {
                 RtspUri = _uri,
                 Session = session
@@ -240,7 +241,7 @@ namespace RtspClientExample
         public void Play(DateTime seekTime, double speed = 1.0)
         {
             if (rtspSocket is null || _uri is null) { throw new InvalidOperationException("Not connected"); }
-            RtspRequest playMessage = new RtspRequestPlay
+            var playMessage = new RtspRequestPlay
             {
                 RtspUri = _uri,
                 Session = session,
@@ -260,7 +261,8 @@ namespace RtspClientExample
         {
             if (rtspSocket is null || _uri is null) { throw new InvalidOperationException("Not connected"); }
             if (seekTimeFrom > seekTimeTo) { throw new ArgumentOutOfRangeException(nameof(seekTimeFrom), "Starting seek cannot be major than ending seek."); }
-            RtspRequest playMessage = new RtspRequestPlay
+
+            var playMessage = new RtspRequestPlay
             {
                 RtspUri = _uri,
                 Session = session,

--- a/RtspClientExample/RTSPMessageAuthExtension.cs
+++ b/RtspClientExample/RTSPMessageAuthExtension.cs
@@ -18,16 +18,5 @@ namespace RtspClientExample
             message.Headers.Remove(RtspHeaderNames.Authorization);
             message.Headers.Add(RtspHeaderNames.Authorization, authorization);
         }
-
-        public static void AddPlayback(this RtspMessage message, DateTime seekTime, double scale = 1.0)
-        {
-            message.Headers.Add(RtspHeaderNames.Scale, $"{scale:0.0}");
-            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTime:yyyyMMdd}T{seekTime:HHmmss}Z-");
-        }
-        public static void AddPlayback(this RtspMessage message, DateTime seekTimeFrom, DateTime seekTimeTo, double scale = 1.0)
-        {
-            message.Headers.Add(RtspHeaderNames.Scale, $"{scale:0.0}");
-            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTimeFrom:yyyyMMdd}T{seekTimeFrom:HHmmss}Z-{seekTimeTo:yyyyMMdd}T{seekTimeTo:HHmmss}Z");
-        }
     }
 }

--- a/RtspClientExample/RTSPMessageAuthExtension.cs
+++ b/RtspClientExample/RTSPMessageAuthExtension.cs
@@ -1,8 +1,6 @@
 ﻿using Rtsp;
 using Rtsp.Messages;
 using System;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace RtspClientExample
 {
@@ -16,7 +14,20 @@ namespace RtspClientExample
             }
 
             string authorization = authentication.GetResponse(commandCounter, uri.AbsoluteUri, message.Method, []);
+            // remove if already one...
+            message.Headers.Remove(RtspHeaderNames.Authorization);
             message.Headers.Add(RtspHeaderNames.Authorization, authorization);
+        }
+
+        public static void AddPlayback(this RtspMessage message, DateTime seekTime, double scale = 1.0)
+        {
+            message.Headers.Add(RtspHeaderNames.Scale, $"{scale:0.0}");
+            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTime:yyyyMMdd}T{seekTime:HHmmss}Z-");
+        }
+        public static void AddPlayback(this RtspMessage message, DateTime seekTimeFrom, DateTime seekTimeTo, double scale = 1.0)
+        {
+            message.Headers.Add(RtspHeaderNames.Scale, $"{scale:0.0}");
+            message.Headers.Add(RtspHeaderNames.Range, $"clock={seekTimeFrom:yyyyMMdd}T{seekTimeFrom:HHmmss}Z-{seekTimeTo:yyyyMMdd}T{seekTimeTo:HHmmss}Z");
         }
     }
 }


### PR DESCRIPTION
I have added as required an extension message for the playback request.
I have also changed the Client demo for the test (using onvif ProfileG service, since I don't know how to find the playback stream).

To allow the right use for playback request, I have exported a SetupMessageCompleted event, so client can send the right play request.
otherwise I needed to add other redundant properties, in this way is a little more elegant then previous pull request...
I have tested in a camera we have at work, and seems to work, but I am not sure if playback just send always back the jpeg format, or can be changed, need for later investigations...