### PR TITLE
Update RTSPClient.cs

### DIFF
--- a/RtspClientExample/RTSPClient.cs
+++ b/RtspClientExample/RTSPClient.cs
@@ -1043,8 +1043,9 @@ namespace RtspClientExample
                 }
                 else
                 {
+                    var baseUriWithTrailingSlash = new Uri($"{_uri!.ToString()}/");
                     // relative path
-                    controlUri = new Uri(_uri!, sdp_control);
+                    controlUri = new Uri(baseUriWithTrailingSlash, sdp_control);
                 }
 
             }


### PR DESCRIPTION
Hi, 
I would like to offer a small bug fix.
In my case, the RTSP URI was `rtsp://123.456.789.105:8445/somePath`
And, when the *path* doesn't end with a slash, so the previous code is actually deleting the `path` part.
For example, instead of `rtsp://123.456.789.105:8445/somePath/trackID=0` 
We got `rtsp://123.456.789.105:8445/trackID=0` (without the `somePath`).

So my little change fix it.