### PR TITLE
Bug in RtspClient request options response parsing

### DIFF
--- a/RtspClientExample/RTSPClient.cs
+++ b/RtspClientExample/RTSPClient.cs
@@ -630,7 +630,7 @@ namespace RtspClientExample
                 // Eg   DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, OPTIONS, ANNOUNCE, RECORD, GET_PARAMETER]}
                 if (message.Headers.ContainsKey(RtspHeaderNames.Public))
                 {
-                    string[]? parts = message.Headers[RtspHeaderNames.Public]?.Split(' ');
+                    string[]? parts = message.Headers[RtspHeaderNames.Public]?.Split(',');
                     if (parts != null)
                     {
                         foreach (string part in parts)


### PR DESCRIPTION
Hi, I have done a little modification in the RtspClient.
parsing the message header response with just a space is ignoring the GET_PARAMETER equal check, since splitted values contains a comma.
Splitting by comma should be the right way to use it.

(I am sorry, but I am not able to understand how to provide a right test case for this change...) 😞 