### PR TITLE
Port couple parsing error

### DIFF
--- a/RTSP.Tests/Messages/PortCoupleTests.cs
+++ b/RTSP.Tests/Messages/PortCoupleTests.cs
@@ -31,6 +31,14 @@ namespace Rtsp.Messages.Tests
         }
 
         [Test()]
+        public void ParseOneEqualPort()
+        {
+            var pc = PortCouple.Parse("1212-1212");
+            Assert.That(pc.First, Is.EqualTo(1212));
+            Assert.That(pc.IsSecondPortPresent, Is.False);
+        }
+
+        [Test()]
         public void ParseTwoPort()
         {
             var pc = PortCouple.Parse("1212-1215");

--- a/RTSP.Tests/Messages/PortCoupleTests.cs
+++ b/RTSP.Tests/Messages/PortCoupleTests.cs
@@ -52,5 +52,12 @@ namespace Rtsp.Messages.Tests
             var pc = new PortCouple(1212, 1215);
             Assert.That(pc.ToString(), Is.EqualTo("1212-1215"));
         }
+
+        [Test()]
+        public void ToStringOneEqualPort()
+        {
+            var pc = PortCouple.Parse("1212-1212");
+            Assert.That(pc.ToString(), Is.EqualTo("1212"));
+        }
     }
 }

--- a/RTSP/Messages/PortCouple.cs
+++ b/RTSP/Messages/PortCouple.cs
@@ -76,7 +76,13 @@
 
             tempValue = 0;
             if (values.Length > 1)
+            {
                 _ = int.TryParse(values[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out tempValue);
+
+                // this check is needed because some Hanwha's nvr returns a 1-1 as interleaved string, resulting in a 1-1 port couple
+                // will setup ports as 1-0
+                if (tempValue == result.First) { tempValue = 0; }
+            }
 
             result.Second = tempValue;
 


### PR DESCRIPTION
Hell NGraziano.
I have found a possible bug with some nvr softwares (Hanwha specifically).
This nvr returns the port couple as 1-1, instead of 1-0 or 0-1.
I assume, reading from their documentation (sorry, I cannot provide shader it, is under N.D.A.), that some specific models returns coupe as 1-1, assuming it as 1-0.
This cause a bug in the data reading, as video is returned always as control, since is the first channel checked...