### PR TITLE
There is a bug in the CustomControlUri usage (RTSPClient)

### DIFF
--- a/RtspClientExample/RTSPClient.cs
+++ b/RtspClientExample/RTSPClient.cs
@@ -699,7 +699,7 @@ namespace RtspClientExample
 
             // For old sony cameras, we need to use the control uri from the sdp
             var customControlUri = sdp_data.Attributs.FirstOrDefault(x => x.Key == "control");
-            if (customControlUri is not null)
+            if (customControlUri is not null && !string.Equals(customControlUri.Value, "*"))
             {
                 _uri = new Uri(_uri!, customControlUri.Value);
             }


### PR DESCRIPTION
If * is returned, this is added to che uri, but is a bug, * must be ignored...