### PR TITLE
Rtsp sdp parsing not in order as RFC2327.

### DIFF
--- a/RTSP.Tests/RTSP.Tests.csproj
+++ b/RTSP.Tests/RTSP.Tests.csproj
@@ -11,6 +11,7 @@
 	  <None Remove="Rtp\Data\jpeg_1.rtp" />
 	  <None Remove="Rtp\Data\jpeg_2.rtp" />
 	  <None Remove="Sdp\Data\test4.sdp" />
+	  <None Remove="Sdp\Data\test5.sdp" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -27,6 +28,7 @@
 		<EmbeddedResource Include="Sdp\Data\test2.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test3.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test4.sdp" />
+		<EmbeddedResource Include="Sdp\Data\test5.sdp" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\RTSP\RTSP.csproj" />

--- a/RTSP.Tests/Sdp/Data/test5.sdp
+++ b/RTSP.Tests/Sdp/Data/test5.sdp
@@ -1,0 +1,11 @@
+﻿v=0
+c=IN IP4 0.0.0.0
+o=- 98969043 98969053 IN IP4 172.30.139.205
+s=Session99
+m=video 0 RTP/AVP 98
+c=IN IP4 0.0.0.0
+a=rtpmap:98 H264/90000
+a=fmtp:98 packetization-mode=1; profile-level-id=4d401f; sprop-parameter-sets=Z01AH42NQCgC3/gLcBAQFAAAD6AAALuDoYAGMsAAb5Qu8uNDAAxlgADfKF3lwoA=,aO44gA==
+a=framerate:6.25
+a=control:trackID=0
+a=recvonly

--- a/RTSP.Tests/Sdp/SdpFileTest.cs
+++ b/RTSP.Tests/Sdp/SdpFileTest.cs
@@ -124,5 +124,31 @@ namespace Rtsp.Sdp.Tests
                 () => SdpFile.Read(testReader, true),
                 Throws.InstanceOf<InvalidDataException>());
         }
+
+        [Test]
+        public void Read5()
+        {
+            using var sdpFile = selfAssembly.GetManifestResourceStream("RTSP.Tests.Sdp.Data.test5.sdp");
+            using var testReader = new StreamReader(sdpFile);
+            SdpFile sdp = SdpFile.Read(testReader, true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sdp.Version, Is.EqualTo(0));
+                Assert.That(sdp.Session, Is.EqualTo("Session99"));
+                Assert.That(sdp.Origin.Username, Is.EqualTo("-"));
+                Assert.That(sdp.Origin.SessionId, Is.EqualTo("98969043"));
+                Assert.That(sdp.Origin.SessionVersion, Is.EqualTo("98969053"));
+                Assert.That(sdp.Origin.NetType, Is.EqualTo("IN"));
+                Assert.That(sdp.Origin.AddressType, Is.EqualTo("IP4"));
+                Assert.That(sdp.Origin.UnicastAddress, Is.EqualTo("172.30.139.205"));
+                Assert.That(sdp.Attributs, Has.Count.EqualTo(0));
+                Assert.That(sdp.Medias, Has.Count.EqualTo(1));
+                Assert.That(sdp.Medias[0].Attributs, Has.Count.EqualTo(5));
+                Assert.That(sdp.Medias[0].Connections, Has.Count.EqualTo(1));
+                Assert.That(sdp.Medias[0].Connections[0].Host, Is.EqualTo("0.0.0.0"));
+            });
+
+        }
     }
 }

--- a/RTSP/Sdp/SdpFile.cs
+++ b/RTSP/Sdp/SdpFile.cs
@@ -37,155 +37,103 @@ namespace Rtsp.Sdp
 #pragma warning restore MA0051 // Method is too long
         {
             SdpFile returnValue = new();
-            var value = GetKeyValue(sdpStream);
+            KeyValuePair<char, string> value;   //= GetKeyValue(sdpStream);
 
-            // Version mandatory
-            if (value.Key == 'v')
+            while ((value = GetKeyValue(sdpStream)).Key != '\0')
             {
-                returnValue.Version = int.Parse(value.Value, CultureInfo.InvariantCulture);
-                value = GetKeyValue(sdpStream);
-            }
-            else
-            {
-                throw new InvalidDataException("version missing");
-            }
 
-            // Origin mandatory
-            if (value.Key == 'o')
-            {
-                returnValue.Origin = Origin.Parse(value.Value);
-                value = GetKeyValue(sdpStream);
-            }
-            else
-            {
-                throw new InvalidDataException("origin missing");
-            }
-
-            // Session mandatory.
-
-            if (value.Key == 's')
-            {
-                returnValue.Session = value.Value;
-                value = GetKeyValue(sdpStream);
-            }
-            else
-            {
-                // However the MuxLab HDMI Encoder (TX-500762) Firmware 1.0.6
-                // does not include the 'Session' so supress InvalidDatarException
-                if (strictParsing)
-                    throw new InvalidDataException("session missing");
-            }
-
-            // Session Information optional
-            if (value.Key == 'i')
-            {
-                returnValue.SessionInformation = value.Value;
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Uri optional
-            if (value.Key == 'u')
-            {
-                try
+                switch (value.Key)
                 {
-                    returnValue.Url = new Uri(value.Value);
-                }
-                catch (UriFormatException err)
-                {
-                    /* skip if cannot parse, some cams returns empty or invalid values for optional ones */
-                    if (strictParsing)
-                        throw new InvalidDataException($"uri value invalid {value.Value}", err);
-                }
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Email optional
-            if (value.Key == 'e')
-            {
-                returnValue.Email = value.Value;
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Phone optional
-            if (value.Key == 'p')
-            {
-                returnValue.Phone = value.Value;
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Connection optional
-            if (value.Key == 'c')
-            {
-                returnValue.Connection = Connection.Parse(value.Value);
-                value = GetKeyValue(sdpStream);
-            }
-
-            // bandwidth optional
-            if (value.Key == 'b')
-            {
-                returnValue.Bandwidth = Bandwidth.Parse(value.Value);
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Timing mandatory
-            while (value.Key == 't')
-            {
-                string timing = value.Value;
-                string repeat = string.Empty;
-                value = GetKeyValue(sdpStream);
-                if (value.Key == 'r')
-                {
-                    repeat = value.Value;
-                    value = GetKeyValue(sdpStream);
-                }
-                returnValue.Timings.Add(Timing.Parse(timing, repeat));
-            }
-
-            // timezone optional
-            if (value.Key == 'z')
-            {
-                returnValue.TimeZone = SdpTimeZone.ParseInvariant(value.Value);
-                value = GetKeyValue(sdpStream);
-            }
-
-            // encryption key optional
-            if (value.Key == 'k')
-            {
-                // Obsolete in RFC 8866 ignored
-                value = GetKeyValue(sdpStream);
-            }
-
-            //Attribute optional multiple
-            while (value.Key == 'a')
-            {
-                returnValue.Attributs.Add(Attribut.ParseInvariant(value.Value));
-                value = GetKeyValue(sdpStream);
-            }
-
-            // Hack for MuxLab HDMI Encoder (TX-500762) Firmware 1.0.6
-            // Skip over all other Key/Value pairs until the 'm=' key
-            while (value.Key != 'm' && value.Key != '\0')
-            {
-                if (strictParsing)
-                    throw new InvalidDataException("Unexpected key/value pair");
-
-                value = GetKeyValue(sdpStream);
-
-                // For old sony SNC-CS20 we need to collect all attributes
-                //Attribute optional multiple
-                while (value.Key == 'a')
-                {
-                    returnValue.Attributs.Add(Attribut.ParseInvariant(value.Value));
-                    value = GetKeyValue(sdpStream);
+                    case 'v':
+                        {
+                            returnValue.Version = int.Parse(value.Value, CultureInfo.InvariantCulture);
+                        }
+                        break;
+                    case 'o':
+                        {
+                            returnValue.Origin = Origin.Parse(value.Value);
+                        }
+                        break;
+                    case 's':
+                        {
+                            returnValue.Session = value.Value;
+                        }
+                        break;
+                    case 'i':
+                        {
+                            returnValue.SessionInformation = value.Value;
+                        }
+                        break;
+                    case 'u':
+                        {
+                            try
+                            {
+                                returnValue.Url = new Uri(value.Value);
+                            }
+                            catch (UriFormatException err)
+                            {
+                                /* skip if cannot parse, some cams returns empty or invalid values for optional ones */
+                                if (strictParsing)
+                                    throw new InvalidDataException($"uri value invalid {value.Value}", err);
+                            }
+                        }
+                        break;
+                    case 'e':
+                        {
+                            returnValue.Email = value.Value;
+                        }
+                        break;
+                    case 'p':
+                        {
+                            returnValue.Phone = value.Value;
+                        }
+                        break;
+                    case 'c':
+                        {
+                            returnValue.Connection = Connection.Parse(value.Value);
+                        }
+                        break;
+                    case 'b':
+                        {
+                            returnValue.Bandwidth = Bandwidth.Parse(value.Value);
+                        }
+                        break;
+                    case 't':
+                        {
+                            string timing = value.Value;
+                            returnValue.Timings.Add(Timing.Parse(timing));
+                        }
+                        break;
+                    case 'r':
+                        {
+                            // todo...
+                        }
+                        break;
+                    case 'z':
+                        {
+                            returnValue.TimeZone = SdpTimeZone.ParseInvariant(value.Value);
+                        }
+                        break;
+                    case 'a':
+                        {
+                            returnValue.Attributs.Add(Attribut.ParseInvariant(value.Value));
+                        }
+                        break;
+                    case 'm':
+                        {
+                            while (value.Key == 'm')
+                            {
+                                Media newMedia = ReadMedia(sdpStream, ref value);
+                                returnValue.Medias.Add(newMedia);
+                            }
+                        }
+                        break;
                 }
             }
 
-            // Media
-            while (value.Key == 'm')
-            {
-                Media newMedia = ReadMedia(sdpStream, ref value);
-                returnValue.Medias.Add(newMedia);
-            }
+            if (returnValue.Version == -1) { throw new InvalidDataException("version missing"); }
+            if (returnValue.Origin is null) { throw new InvalidDataException("origin missing"); }
+            if (string.IsNullOrEmpty(returnValue.Session) && strictParsing) { throw new InvalidDataException("session missing"); }
 
             return returnValue;
         }
@@ -232,7 +180,7 @@ namespace Rtsp.Sdp
             return returnValue;
         }
 
-        public int Version { get; set; }
+        public int Version { get; set; } = -1;
 
         public Origin? Origin { get; set; }
 

--- a/RTSP/Sdp/SdpFile.cs
+++ b/RTSP/Sdp/SdpFile.cs
@@ -134,6 +134,7 @@ namespace Rtsp.Sdp
             if (returnValue.Version == -1) { throw new InvalidDataException("version missing"); }
             if (returnValue.Origin is null) { throw new InvalidDataException("origin missing"); }
             if (string.IsNullOrEmpty(returnValue.Session) && strictParsing) { throw new InvalidDataException("session missing"); }
+            if (returnValue.Medias.Count == 0) { throw new InvalidDataException("media information(s) missing"); }
 
             return returnValue;
         }

--- a/RTSP/Sdp/Timing.cs
+++ b/RTSP/Sdp/Timing.cs
@@ -8,7 +8,7 @@ namespace Rtsp.Sdp
         public required long StartTime { get; init; }
         public required long StopTime { get; init; }
 
-        internal static Timing Parse(string timing, string _)
+        internal static Timing Parse(string timing)
         {
             var parts = timing.Split(' ');
             if (parts.Length != 2)
@@ -25,12 +25,17 @@ namespace Rtsp.Sdp
                 throw new ArgumentException("Invalid timing format, stop time is not a number", nameof(timing));
             }
 
-            // TODO: Parse repeat
             return new()
             {
                 StartTime = start,
                 StopTime = stop,
             };
         }
+
+        internal void ParseRepeat()
+        {
+            // TODO: parse repeat...
+        }
+        
     }
 }


### PR DESCRIPTION
Some cameras and NVRs returns an sdp with a wrong order (not for multiple line composed methods).
I have changed the sdp reading, which will not read in a mandatory order, but with a while.
This will ensure also older cameras can be readed (example from real camera in sdp.test5 file).
some NVR from Hanwha, anyway, returns the sdp with wrong i= position (2nd line instead of 4th+ line).
The mandatory check (for protocol, owner, session and media) will be in the end, not in the 'v', 'o', 's' or 'm' value reading.