### PR TITLE
poc example of rtsps support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ RTSP.Tests/Coverage/
 .vs/
 *.TMP
 *.user
+.idea/

--- a/RTSP.Tests/Integration/RTSPListenerIntegrationTests.cs
+++ b/RTSP.Tests/Integration/RTSPListenerIntegrationTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rtsp.Messages;
+
+namespace Rtsp.Tests.Integration;
+
+/// <summary>
+/// RtspListenerIntegrationTests - These tests use the RtspTcpTransport and RtspListener to connect to a server (e.g. MediaMTX)
+/// These have been marked as Category Integration to allow filtration out of continuous integration pipelines
+/// To run these tests follow the guidelines on <see cref="https://github.com/bluenviron/mediamtx?tab=readme-ov-file#rtsp-specific-features"/>
+/// - Enable RTSPS in MediaMtx on port 8322 and rtsp on port 8554
+/// - Use Rest API to add a remote stream to MediaMtx on the /Test path
+/// - Use Wireshark to listen for traffic on local loopback with filter "tcp.port == 8322 || tcp.port == 8554"
+/// - Run Test
+/// - Observe TLS/SSL handshake and communication between client and server
+/// </summary>
+public class RTSPListenerIntegrationTests
+{
+    private readonly Dictionary<RtspRequest, (TaskCompletionSource<RtspResponse>, DateTime)> _messageQueue
+        = new();
+
+    private readonly object _lock = new();
+    
+    [TestCase("localhost", 8554, "rtsp://localhost:8554/Test", false)]
+    [TestCase("localhost", 8322,"rtsps://localhost:8322/Test", true)]
+    [Category("Integration")]
+    public async Task SendOption_WhenSent_Receives200OK(string address, int port, string uri, bool enableSsl)
+    {
+        // arrange
+        var socket = new RtspTcpTransport(new TcpClient(address, port));
+        var listener = new RtspListener(socket, enableSsl:enableSsl);
+        var taskCompletionSource = new TaskCompletionSource<RtspResponse>();
+        listener.MessageReceived += ListenerOnMessageReceived;
+        listener.Start();
+        
+        var message = new RtspRequestOptions
+        {
+            RtspUri = new Uri(uri)
+        };
+        
+        // act
+        if (listener.SendMessage(message))
+        {
+            lock (_lock)
+            {
+                _messageQueue.Add(message, (taskCompletionSource, DateTime.Now));
+            }
+            
+            var result = await taskCompletionSource.Task;
+            
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.ReturnCode, Is.EqualTo(200));
+        }
+        else
+        {
+            Assert.Fail("Unable to send message");
+        }
+    }
+
+    private void ListenerOnMessageReceived(object? sender, RtspChunkEventArgs e)
+    {
+        RtspResponse? message = e.Message as RtspResponse;
+
+        lock (_lock)
+        {
+            if (_messageQueue.ContainsKey(message.OriginalRequest))
+            {
+                _messageQueue[message.OriginalRequest].Item1.SetResult(message);
+                _messageQueue.Remove(message.OriginalRequest);
+            }
+        }
+    }
+}

--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -1,4 +1,8 @@
-﻿namespace Rtsp
+﻿using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Rtsp
 {
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
@@ -29,6 +33,8 @@
 
         private int _sequenceNumber;
 
+        private readonly bool _enableSsl;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RtspListener"/> class from a TCP connection.
         /// </summary>
@@ -37,14 +43,31 @@
         public RtspListener(
             IRtspTransport connection,
             ILogger<RtspListener>? logger = null,
-            MemoryPool<byte>? memoryPool = null
+            MemoryPool<byte>? memoryPool = null,
+            bool enableSsl = false
             )
         {
             _logger = logger as ILogger ?? NullLogger.Instance;
             _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
-
+            _enableSsl = enableSsl;
             _transport = connection ?? throw new ArgumentNullException(nameof(connection));
-            _stream = connection.GetStream();
+            _stream = GetStream();
+        }
+
+        private bool RemoteCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslpolicyerrors)
+        {
+            // todo: allow the validation of remote certificate to be handled by user
+            if (sslpolicyerrors == SslPolicyErrors.None)
+                return true;
+
+            // returning false will cause the stream to not be opened for writing
+            if ((sslpolicyerrors & SslPolicyErrors.RemoteCertificateNotAvailable) != 0)
+                return false;
+            
+            _logger.LogWarning("Certificate Error: {SslPolicyErrors}", sslpolicyerrors);
+            
+            // return true, even for server certificate name mismatches
+            return true;
         }
 
         /// <summary>
@@ -279,14 +302,34 @@
 
             // reconnect 
             _transport.Reconnect();
-            _stream = _transport.GetStream();
+            _stream = GetStream();
 
             // If listen thread exist restart it
             if (_mainTask != null)
                 Start();
         }
 
-        private readonly List<byte> readOneMessageBuffer = new(256);
+        private readonly List<byte> _readOneMessageBuffer = new(256);
+        
+        private Stream GetStream() {
+            // if enableSSL flag is true, wrap the stream with the SslStream and a callback for validating the remote certificate
+            if (_enableSsl)
+            {
+                var sslStream = new SslStream(_transport.GetStream(), true, RemoteCertificateValidationCallback, null);
+                try
+                {
+                    sslStream.AuthenticateAsClient(_transport.RemoteAddress);
+                    return sslStream;
+                }
+                catch (AuthenticationException authException)
+                {
+                    _logger.LogError("Exception occurred authenticating with remote server: {AuthException}", authException.Message);
+                }
+            }
+
+            return _transport.GetStream();
+        }
+            
 
         /// <summary>
         /// Reads one message.
@@ -305,7 +348,7 @@
 
             int size = 0;
             int byteReaden = 0;
-            readOneMessageBuffer.Clear();
+            _readOneMessageBuffer.Clear();
             string oneLine = string.Empty;
             while (currentReadingState != ReadingState.End)
             {
@@ -327,20 +370,20 @@
                                 needMoreChar = false;
                                 break;
                             case '\n':
-                                oneLine = Encoding.UTF8.GetString(readOneMessageBuffer.ToArray());
-                                readOneMessageBuffer.Clear();
+                                oneLine = Encoding.UTF8.GetString(_readOneMessageBuffer.ToArray());
+                                _readOneMessageBuffer.Clear();
                                 needMoreChar = false;
                                 break;
                             case '\r':
                                 // simply ignore this
                                 break;
                             // if first caracter of packet is $ it is an interleaved data packet
-                            case '$' when currentReadingState == ReadingState.NewCommand && readOneMessageBuffer.Count == 0:
+                            case '$' when currentReadingState == ReadingState.NewCommand && _readOneMessageBuffer.Count == 0:
                                 currentReadingState = ReadingState.InterleavedData;
                                 needMoreChar = false;
                                 break;
                             default:
-                                readOneMessageBuffer.Add((byte)currentByte);
+                                _readOneMessageBuffer.Add((byte)currentByte);
                                 break;
                         }
                     }
@@ -592,6 +635,7 @@
             {
                 Stop();
                 _stream?.Dispose();
+                _cancelationTokenSource?.Dispose();
             }
         }
 


### PR DESCRIPTION
- added example test using Media-MTX as the rtsp server on port 8332
- essentially, you replace the Stream with an SSLStream wrapper that handles the encryption and decryption of the data.
- calling AuthenticateAsClient is important to permit opening the stream for writing
- the RemoteCertificateValidationCallback is set up to only fail if there is no Remote Certificate configured. This would obviously need to be extended to allow the user to define the appropriate validation strategy