### PR TITLE
Hotfix/connection parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ RTSP.Tests/Coverage/
 .vs/
 *.TMP
 *.user
+.idea/

--- a/RTSP.Tests/RTSP.Tests.csproj
+++ b/RTSP.Tests/RTSP.Tests.csproj
@@ -29,9 +29,7 @@
 		<EmbeddedResource Include="Sdp\Data\test3.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test4.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test5.sdp" />
-		<None Remove="Sdp\Data\test6.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test6.sdp" />
-		<None Remove="Sdp\Data\test7.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test7.sdp" />
 	</ItemGroup>
 	<ItemGroup>

--- a/RTSP.Tests/RTSP.Tests.csproj
+++ b/RTSP.Tests/RTSP.Tests.csproj
@@ -29,6 +29,10 @@
 		<EmbeddedResource Include="Sdp\Data\test3.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test4.sdp" />
 		<EmbeddedResource Include="Sdp\Data\test5.sdp" />
+		<None Remove="Sdp\Data\test6.sdp" />
+		<EmbeddedResource Include="Sdp\Data\test6.sdp" />
+		<None Remove="Sdp\Data\test7.sdp" />
+		<EmbeddedResource Include="Sdp\Data\test7.sdp" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\RTSP\RTSP.csproj" />

--- a/RTSP.Tests/Sdp/Data/test6.sdp
+++ b/RTSP.Tests/Sdp/Data/test6.sdp
@@ -1,0 +1,15 @@
+v=0
+o=- 1109162014219182 0 IN IP4 0.0.0.0
+s=HIK Media Server V3.0.2
+i=HIK Media Server Session Description : standard
+e=NONE
+c=IN c=IN IP4 0.0.0.0
+t=0 0
+a=control:*
+a=range:npt=now-
+m=video 0 RTP/AVP 96
+a=rtpmap:96 H264/90000
+a=fmtp:96 profile-level-id=4D0014;packetization-mode=0;sprop-parameter-sets=Z2QAFK2EAQwgCGEAQwgCGEAQwgCEK3Cw/QgAAOpgAAr8hCA=,aO48sA==
+a=control:trackID=video
+a=Media_header:MEDIAINFO=494D4B48010100000400000100000000000000000000000000000000000000000000000000000000;
+a=appversion:1.0

--- a/RTSP.Tests/Sdp/Data/test7.sdp
+++ b/RTSP.Tests/Sdp/Data/test7.sdp
@@ -1,0 +1,11 @@
+v=0
+c=IN IP6 FF1E:03AD::7F2E:172A:1E24
+o=- 98969043 98969053 IN IP6 2201:056D::112E:144A:1E24
+s=Session99
+m=video 0 RTP/AVP 98
+c=IN IP4 0.0.0.0
+a=rtpmap:98 H264/90000
+a=fmtp:98 packetization-mode=1; profile-level-id=4d401f; sprop-parameter-sets=Z01AH42NQCgC3/gLcBAQFAAAD6AAALuDoYAGMsAAb5Qu8uNDAAxlgADfKF3lwoA=,aO44gA==
+a=framerate:6.25
+a=control:trackID=0
+a=recvonly

--- a/RTSP.Tests/Sdp/SdpFileTest.cs
+++ b/RTSP.Tests/Sdp/SdpFileTest.cs
@@ -234,5 +234,55 @@ namespace Rtsp.Sdp.Tests
             });
 
         }
+        
+        [Test]
+        public void Read6Loose()
+        {
+            using var sdpFile = selfAssembly.GetManifestResourceStream("RTSP.Tests.Sdp.Data.test6.sdp");
+            using var testReader = new StreamReader(sdpFile);
+            SdpFile sdp = SdpFile.ReadLoose(testReader);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sdp.Version, Is.EqualTo(0));
+                Assert.That(sdp.Session, Is.EqualTo("HIK Media Server V3.0.2"));
+                Assert.That(sdp.Origin.Username, Is.EqualTo("-"));
+                Assert.That(sdp.Origin.SessionId, Is.EqualTo("1109162014219182"));
+                Assert.That(sdp.Origin.SessionVersion, Is.EqualTo("0"));
+                Assert.That(sdp.Origin.NetType, Is.EqualTo("IN"));
+                Assert.That(sdp.Origin.AddressType, Is.EqualTo("IP4"));
+                Assert.That(sdp.Origin.UnicastAddress, Is.EqualTo("0.0.0.0"));
+                Assert.That(sdp.Connection.Host, Is.EqualTo("0.0.0.0"));
+                Assert.That(sdp.Attributs, Has.Count.EqualTo(2));
+                Assert.That(sdp.Medias, Has.Count.EqualTo(1));
+                Assert.That(sdp.Medias[0].Attributs, Has.Count.EqualTo(5));
+            });
+
+        }
+        
+        [Test]
+        public void Read7Loose()
+        {
+            using var sdpFile = selfAssembly.GetManifestResourceStream("RTSP.Tests.Sdp.Data.test7.sdp");
+            using var testReader = new StreamReader(sdpFile);
+            SdpFile sdp = SdpFile.ReadLoose(testReader);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sdp.Version, Is.EqualTo(0));
+                Assert.That(sdp.Session, Is.EqualTo("Session99"));
+                Assert.That(sdp.Origin.Username, Is.EqualTo("-"));
+                Assert.That(sdp.Origin.SessionId, Is.EqualTo("98969043"));
+                Assert.That(sdp.Origin.SessionVersion, Is.EqualTo("98969053"));
+                Assert.That(sdp.Origin.NetType, Is.EqualTo("IN"));
+                Assert.That(sdp.Origin.AddressType, Is.EqualTo("IP6"));
+                Assert.That(sdp.Origin.UnicastAddress, Is.EqualTo("2201:056D::112E:144A:1E24"));
+                Assert.That(sdp.Connection.Host, Is.EqualTo("FF1E:03AD::7F2E:172A:1E24"));
+                Assert.That(sdp.Attributs, Has.Count.EqualTo(0));
+                Assert.That(sdp.Medias, Has.Count.EqualTo(1));
+                Assert.That(sdp.Medias[0].Attributs, Has.Count.EqualTo(5));
+            });
+
+        }
     }
 }

--- a/RTSP/Sdp/Connection.cs
+++ b/RTSP/Sdp/Connection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -7,9 +6,9 @@ namespace Rtsp.Sdp
 {
     public abstract class Connection
     {
-        private static string _ConnectionRegexString = @"IN (?<Type>(IP4|IP6)) (?<Address>[0-9a-zA-Z\.\/\:]*)";
+        private const string _ConnectionRegexString = @"IN (?<Type>(IP4|IP6)) (?<Address>[0-9a-zA-Z\.\/\:]*)";
 
-        private static Regex _ConnectionRegex = new Regex(_ConnectionRegexString);
+        private static Regex _ConnectionRegex = new(_ConnectionRegexString);
         
         public string Host { get; set; } = string.Empty;
 


### PR DESCRIPTION
Change implementation to a regex check for the format rather than hard split on spacing characters. This should try and match and find a valid entry for the connection parameter, even if the camera is including some errant characters (see Test6)

Also added in a test using sample IPv6 from [here](https://datatracker.ietf.org/doc/html/rfc3266#section-4)