### PR TITLE
Fix #131, replace RemoteAdress [sic] with IPEndPoint based properties

### DIFF
--- a/RTSP/IRTSPTransport.cs
+++ b/RTSP/IRTSPTransport.cs
@@ -1,4 +1,7 @@
-﻿namespace Rtsp
+using System;
+using System.Net;
+
+namespace Rtsp
 {
     /// <summary>
     /// Interface for Transport of Rtsp (TCP, TCP+SSL,..)
@@ -11,11 +14,25 @@
         /// <returns>A stream</returns>
         System.IO.Stream GetStream();
 
+        [Obsolete("Get the address from the RemoteEndPoint instead.")]
         /// <summary>
         /// Gets the remote address.
         /// </summary>
         /// <value>The remote address.</value>
+        /// <remarks>This property actually returns an IP:Port pair or a URI, depending on the underlying transport.</remarks>
         string RemoteAddress { get; }
+
+        /// <summary>
+        /// Gets the remote endpoint.
+        /// </summary>
+        /// <value>The remote endpoint.</value>
+        IPEndPoint RemoteEndPoint { get; }
+
+        /// <summary>
+        /// Gets the remote endpoint.
+        /// </summary>
+        /// <value>The remote endpoint.</value>
+        IPEndPoint LocalEndPoint { get; }
 
         /// <summary>
         /// Get next command index. Increment at each call.

--- a/RTSP/RTSPHttpTransport.cs
+++ b/RTSP/RTSPHttpTransport.cs
@@ -169,14 +169,27 @@ namespace Rtsp
         private uint _commandCounter;
         private bool disposedValue;
 
+        private IPEndPoint _localEndPoint;
+        private IPEndPoint _remoteEndPoint;
+
         public RtspHttpTransport(Uri uri, NetworkCredential credentials)
         {
             _credentials = credentials;
             _uri = uri;
             Reconnect();
+            if (_dataClient is null)
+            {
+                throw new InvalidOperationException("The HTTP client could not be opened.");
+            }
+            _localEndPoint = _dataClient.Client.LocalEndPoint as IPEndPoint ?? throw new InvalidOperationException("The local endpoint can not be determined.");
+            _remoteEndPoint = _dataClient.Client.RemoteEndPoint as IPEndPoint ?? throw new InvalidOperationException("The remote endpoint can not be determined.");
         }
 
         public string RemoteAddress => _uri.ToString();
+
+        public IPEndPoint LocalEndPoint => _localEndPoint;
+        public IPEndPoint RemoteEndPoint => _remoteEndPoint;
+
         public bool Connected => _dataClient?.Connected == true;
 
         public uint NextCommandIndex() => ++_commandCounter;

--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.IO.Pipelines;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -51,11 +52,25 @@ namespace Rtsp
             _stream = connection.GetStream();
         }
 
+        [Obsolete("Get the address from the RemoteEndPoint instead.")]
         /// <summary>
         /// Gets the remote address.
         /// </summary>
-        /// <value>The remote adress.</value>
-        public string RemoteAdress => _transport.RemoteAddress;
+        /// <value>The remote address.</value>
+        /// <remarks>In addition to being misspelled, this property actually returns an IP:port pair.</remarks>
+        public string RemoteAdress => RemoteEndPoint.Address.ToString();
+
+        /// <summary>
+        /// Gets the remote endpoint.
+        /// </summary>
+        /// <value>The remote endpoint.</value>
+        public IPEndPoint RemoteEndPoint => _transport.RemoteEndPoint;
+
+        /// <summary>
+        /// Gets the local enpoint.
+        /// </summary>
+        /// <value>The local endpoint.</value>
+        public IPEndPoint LocalEndPoint => _transport.LocalEndPoint;
 
         /// <summary>
         /// Starts this instance.
@@ -141,7 +156,7 @@ namespace Rtsp
                     {
                         // on logue le tout
                         if (currentMessage.SourcePort != null)
-                            _logger.LogDebug("Receive from {remoteAdress}", currentMessage.SourcePort.RemoteAdress);
+                            _logger.LogDebug("Receive from {remoteAdress}", currentMessage.SourcePort.RemoteEndPoint);
                         _logger.LogDebug("{message}", currentMessage);
                     }
                     switch (currentMessage)

--- a/RTSP/RTSPTCPTransport.cs
+++ b/RTSP/RTSPTCPTransport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
@@ -13,6 +13,7 @@ namespace Rtsp
     public class RtspTcpTransport : IRtspTransport, IDisposable
     {
         private readonly IPEndPoint _currentEndPoint;
+        private readonly IPEndPoint _localEndPoint;
         private TcpClient _RtspServerClient;
         private uint _commandCounter;
 
@@ -26,7 +27,8 @@ namespace Rtsp
                 throw new ArgumentNullException(nameof(tcpConnection));
             Contract.EndContractBlock();
 
-            _currentEndPoint = tcpConnection.Client.RemoteEndPoint as IPEndPoint ?? throw new InvalidOperationException("The remote endpoint can not be get");
+            _currentEndPoint = tcpConnection.Client.RemoteEndPoint as IPEndPoint ?? throw new InvalidOperationException("The local endpoint can not be determined.");
+            _localEndPoint = tcpConnection.Client.LocalEndPoint as IPEndPoint ?? throw new InvalidOperationException("The remote endpoint can not be determined.");
             _RtspServerClient = tcpConnection;
         }
 
@@ -50,7 +52,20 @@ namespace Rtsp
         /// Gets the remote address.
         /// </summary>
         /// <value>The remote address.</value>
-        public string RemoteAddress => string.Format(CultureInfo.InvariantCulture, "{0}:{1}", _currentEndPoint.Address, _currentEndPoint.Port);
+        public string RemoteAddress => _currentEndPoint.ToString();
+
+        /// <summary>
+        /// Gets the remote endpoint.
+        /// </summary>
+        /// <value>The remote endpoint.</value>
+        public IPEndPoint RemoteEndPoint => _currentEndPoint;
+
+        /// <summary>
+        /// Gets the local endpoint.
+        /// </summary>
+        /// <value>The local endpoint.</value>
+        public IPEndPoint LocalEndPoint => _localEndPoint;
+
 
         public uint NextCommandIndex() => ++_commandCounter;
 
@@ -67,6 +82,7 @@ namespace Rtsp
         /// </summary>
         /// <value><see langword="true"/> if connected; otherwise, <see langword="false"/>.</value>
         public bool Connected => _RtspServerClient.Client != null && _RtspServerClient.Connected;
+
 
         /// <summary>
         /// Reconnect this instance.

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -257,7 +257,7 @@ namespace RtspCameraExample
             // Update the RTSP Keepalive Timeout
             lock (rtspConnectionList)
             {
-                foreach (var oneConnection in rtspConnectionList.Where(connection => connection.Listener.RemoteAdress == listener.RemoteAdress))
+                foreach (var oneConnection in rtspConnectionList.Where(connection => connection.Listener.RemoteEndPoint.Equals(listener.RemoteEndPoint)))
                 {
                     // found the connection
                     oneConnection.UpdateKeepAlive();
@@ -367,8 +367,8 @@ namespace RtspCameraExample
                 // RTP over UDP mode
                 // Create a pair of UDP sockets - One is for the Data (eg Video/Audio), one is for the RTCP
                 var udp_pair = new UDPSocket(50000, 51000); // give a range of 500 pairs (1000 addresses) to try incase some address are in use
-                udp_pair.SetDataDestination(listener.RemoteAdress.Split(":")[0], transport.ClientPort.First);
-                udp_pair.SetControlDestination(listener.RemoteAdress.Split(":")[0], transport.ClientPort.Second);
+                udp_pair.SetDataDestination(listener.RemoteEndPoint.Address.ToString(), transport.ClientPort.First);
+                udp_pair.SetControlDestination(listener.RemoteEndPoint.Address.ToString(), transport.ClientPort.Second);
                 udp_pair.ControlReceived += (local_sender, local_e) =>
                 {
                     // RTCP data received
@@ -415,7 +415,7 @@ namespace RtspCameraExample
                 string copy_of_session_id = "";
                 lock (rtspConnectionList)
                 {
-                    foreach (var setupConnection in rtspConnectionList.Where(connection => connection.Listener.RemoteAdress == listener.RemoteAdress))
+                    foreach (var setupConnection in rtspConnectionList.Where(connection => connection.Listener.RemoteEndPoint.Equals(listener.RemoteEndPoint)))
                     {
                         // Check the Track ID to determine if this is a SETUP for the Video Stream
                         // or a SETUP for an Audio Stream.
@@ -626,7 +626,7 @@ namespace RtspCameraExample
                     catch (Exception e)
                     {
                         Console.WriteLine("UDP Write Exception " + e);
-                        Console.WriteLine("Error writing to listener " + connection.Listener.RemoteAdress);
+                        Console.WriteLine("Error writing to listener " + connection.Listener.RemoteEndPoint);
                         Console.WriteLine("Removing session " + connection.session_id + " due to write error");
                         RemoveSession(connection);
                         break; // exit out of foreach loop
@@ -663,7 +663,7 @@ namespace RtspCameraExample
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error writing RTCP to listener {remoteAdress}", connection.Listener.RemoteAdress);
+                _logger.LogError(e, "Error writing RTCP to listener {remoteAdress}", connection.Listener.RemoteEndPoint);
                 return false;
             }
             return true;
@@ -895,7 +895,7 @@ namespace RtspCameraExample
                     catch (Exception e)
                     {
                         _logger.LogWarning(e, "UDP Write Exception");
-                        _logger.LogWarning("Error writing to listener {address}", connection.Listener.RemoteAdress);
+                        _logger.LogWarning("Error writing to listener {address}", connection.Listener.RemoteEndPoint);
                         write_error = true;
                     }
                 }

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -257,7 +257,7 @@ namespace RtspCameraExample
             // Update the RTSP Keepalive Timeout
             lock (rtspConnectionList)
             {
-                foreach (var oneConnection in rtspConnectionList.Where(connection => connection.Listener.RemoteEndPoint.Equals(listener.RemoteEndPoint)))
+                foreach (var oneConnection in rtspConnectionList.Where(connection => connection.Listener == listener))
                 {
                     // found the connection
                     oneConnection.UpdateKeepAlive();


### PR DESCRIPTION
This PR marks RtspListener.IPAdress (and the properties it depends on) as obsolete, and provides new properties for accessing endpoint information.

Existing debugging strings which printed the IP & port number were preserved, and use IPEndPoint.ToString(), which internally uses the InvariantCulture for formatting, resulting in cleaner code.