### PR TITLE
supporting cameras with more than 6 parameters on origin

### DIFF
--- a/RTSP/Sdp/Origin.cs
+++ b/RTSP/Sdp/Origin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace Rtsp.Sdp
 {
@@ -17,7 +18,7 @@ namespace Rtsp.Sdp
             if (originString == null)
                 throw new ArgumentNullException(nameof(originString));
 
-            string[] parts = originString.Split(' ');
+            string[] parts = originString.Split(' ').TakeLast(6).ToArray();
 
             if (parts.Length != 6)
                 throw new FormatException("Number of element invalid in origin string.");


### PR DESCRIPTION
the Tapo C225 has a 7th parameter at the start, which can be dismissed (it's a '-').

what the tapo reports is

o=- p1 p2 p3 p4 p5 p6

i'm not sure why, but "taking the last 6 parameters and checking if there where 6" works.