### PR TITLE
Introduce Efficient Buffer Writer with ReadOnlySequence<byte> Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ Sharp RTSP
 
 [![Nuget](https://img.shields.io/nuget/v/SharpRTSP)](https://www.nuget.org/packages/SharpRTSP)
 
+The source of the nuget package [SharpRTSP](https://www.nuget.org/packages/SharpRTSP)  is in branch [donetcore](https://github.com/ngraziano/SharpRTSP/tree/dotnetcore)
+
 A C# library to build RTSP Clients, RTSP Servers and handle RTP data streams. The library has several examples.
 * RTSP Client Example - will connect to a RTSP server and receive Video and Audio in H264, H265/HEVC, G711, AAC and AMR formats. UDP, TCP and Multicast are supported. The data received is written to files.
 * RTSP Camera Server Example - A YUV Image Generator and a very simple H264 Encoder generate H264 NALs which are then delivered via a RTSP Server to clients
-* RTP Receiver - will recieve RTP and RTCP packets and pass them to a transport handler
+* RTP Receiver - will receieve RTP and RTCP packets and pass them to a transport handler
 * RTSP Server - will accept RTSP connections and talk to clients
 * RTP Sender - will send RTP packets to clients
-* Transport Handler - Transport hanlders for H264, H265/HEVC, G711 and AMR are provided.
+* Transport Handler - Transport handlers for H264, H265/HEVC, G711 and AMR are provided.
 
 **:warning: : This library does not handle the decoding of the video or audio (eg converting H264 into a bitmap). SharpRTSP is limited to the transport layer and generates the raw data that you need to feed into a video decoder or audio decoder. Many people use FFMPEG or use Hardware Accelerated Operating System APIs to do the decoding.**
 
@@ -188,7 +190,7 @@ This is a walkthrough of an **old version** of the RTSP Client Example which hig
 
 * STEP 5 - Handle RTP Video
 
-  This code handles each incoming RTP packet, combining RTP packets that are all part of the same frame of vdeo (using the Marker Bit).
+  This code handles each incoming RTP packet, combining RTP packets that are all part of the same frame of video (using the Marker Bit).
   Once a full frame is received it can be passed to a De-packetiser to get the compressed video data
 
   ```C#

--- a/RTSP.Tests/RTSPListenerTest.cs
+++ b/RTSP.Tests/RTSPListenerTest.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using Rtsp.Messages;
 using RTSP.Tests.TestUtils;
 using System;

--- a/RTSP.Tests/Rtp/JpegPayloadTests.cs
+++ b/RTSP.Tests/Rtp/JpegPayloadTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Rtsp.Rtp;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -52,12 +53,12 @@ namespace RTSP.Tests.Rtp
 
             Assert.Multiple(() =>
             {
-                Assert.That(r0.Data, Is.Empty);
-                Assert.That(r1.Data, Is.Empty);
-                Assert.That(r2.Data, Is.Not.Empty);
+                Assert.That(r0.Data.ToArray(), Is.Empty);
+                Assert.That(r1.Data.ToArray(), Is.Empty);
+                Assert.That(r2.Data.ToArray(), Is.Not.Empty);
             });
 
-            var jpeg = r2.Data.First();
+            var jpeg = r2.Data.First;
             var expected = ReadBytes("img_jpg_0.jpg");
 
             Assert.That(jpeg.ToArray(), Is.EqualTo(expected));

--- a/RTSP.Tests/Rtp/RawMediaFrameTests.cs
+++ b/RTSP.Tests/Rtp/RawMediaFrameTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 namespace Rtsp.Rtp.Tests
@@ -10,10 +11,8 @@ namespace Rtsp.Rtp.Tests
         [Test()]
         public void AnyTest()
         {
-            List<ReadOnlyMemory<byte>> data = [
-                new byte[] {0x01 }.AsMemory(),
-              ];
-            RawMediaFrame rawMediaFrame = new(data, []) { ClockTimestamp = DateTime.MinValue, RtpTimestamp = 0 };
+            ReadOnlySequence<byte> data = new([0x01]);
+            using RawMediaFrame rawMediaFrame = new(data, null) { ClockTimestamp = DateTime.MinValue, RtpTimestamp = 0 };
             Assert.That(rawMediaFrame.Any(), Is.True);
         }
 

--- a/RTSP.Tests/Utils/PooledBufferWriterTests.cs
+++ b/RTSP.Tests/Utils/PooledBufferWriterTests.cs
@@ -1,0 +1,119 @@
+﻿using NUnit.Framework;
+using Rtsp.Utils;
+using System;
+
+namespace RTSP.Tests.Utils;
+
+[TestFixture]
+public class PooledBufferWriterTests
+{
+    [Test]
+    public void WriteSingleByte_ShouldIncreaseLength()
+    {
+        using var writer = new PooledBufferWriter();
+        writer.Write((byte)42);
+
+        Assert.That(writer.Length, Is.EqualTo(1));
+
+        Span<byte> buffer = new byte[1];
+        writer.CopyTo(buffer);
+        Assert.That(buffer[0], Is.EqualTo(42));
+    }
+
+    [Test]
+    public void WriteSpan_ShouldCopyAllBytes()
+    {
+        using var writer = new PooledBufferWriter();
+        byte[] data = [1, 2, 3, 4, 5];
+        writer.Write(data);
+
+        Assert.That(writer.Length, Is.EqualTo(data.Length));
+
+        Span<byte> buffer = new byte[data.Length];
+        writer.CopyTo(buffer);
+        Assert.That(buffer.ToArray(), Is.EqualTo(data));
+    }
+
+    [Test]
+    public void GetMemoryAndAdvance_ShouldTrackLength()
+    {
+        using var writer = new PooledBufferWriter();
+        var span = writer.GetSpan(10);
+        span[0] = 99;
+        writer.Advance(1);
+
+        Assert.That(writer.Length, Is.EqualTo(1));
+
+        Span<byte> buffer = new byte[1];
+        writer.CopyTo(buffer);
+        Assert.That(buffer[0], Is.EqualTo(99));
+    }
+
+    [Test]
+    public void AdvanceBeyondCapacity_ShouldThrow()
+    {
+        using var writer = new PooledBufferWriter();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var span = writer.GetSpan(10);
+            writer.Advance(span.Length + 1);
+        });
+    }
+
+    [Test]
+    public void CopyTo_WithTooSmallDestination_ShouldThrow()
+    {
+        using var writer = new PooledBufferWriter();
+        writer.Write((byte)1);
+        Span<byte> smallBuffer = [];
+
+        Assert.Throws<ArgumentException>(() => writer.CopyTo([]));
+    }
+
+    [Test]
+    public void Clear_ShouldResetLengthAndAllowReuse()
+    {
+        using var writer = new PooledBufferWriter();
+        writer.Write([1, 2, 3]);
+        writer.Clear();
+
+        Assert.That(writer.Length, Is.EqualTo(0));
+
+        writer.Write((byte)9);
+        Span<byte> buffer = new byte[1];
+        writer.CopyTo(buffer);
+        Assert.That(buffer[0], Is.EqualTo(9));
+    }
+
+    [Test]
+    public void Dispose_ShouldNotThrowAndAllowReuse()
+    {
+        using var writer = new PooledBufferWriter();
+        writer.Write((byte)7);
+        writer.Dispose();
+
+        Assert.That(writer.Length, Is.EqualTo(0));
+
+        writer.Write((byte)8);
+        Span<byte> buffer = new byte[1];
+        writer.CopyTo(buffer);
+        Assert.That(buffer[0], Is.EqualTo(8));
+    }
+
+    [Test]
+    public void WriteLargeSpan_ShouldHandleMultipleSegments()
+    {
+        using var writer = new PooledBufferWriter();
+        byte[] data = new byte[10000];
+        for (int i = 0; i < data.Length; i++) data[i] = (byte)(i % 256);
+
+        writer.Write(data);
+
+        Assert.That(writer.Length, Is.EqualTo(data.Length));
+
+        Span<byte> buffer = new byte[data.Length];
+        writer.CopyTo(buffer);
+        Assert.That(buffer.ToArray(), Is.EqualTo(data));
+    }
+}

--- a/RTSP.Tests/Utils/PooledSequenceTests.cs
+++ b/RTSP.Tests/Utils/PooledSequenceTests.cs
@@ -1,0 +1,167 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rtsp.Utils.Tests
+{
+    [TestFixture()]
+    public class PooledSequenceTests
+    {
+        [Test]
+        public void GetReadOnlySequence_ShouldReturnEmpty_WhenNoMemoryRequested()
+        {
+            using var buffer = new PooledSequence();
+
+            var sequence = buffer.GetReadOnlySequence();
+
+            Assert.That(sequence.IsEmpty, Is.True, "Sequence should be empty when no memory has been requested");
+            Assert.That(buffer.Length, Is.EqualTo(0), "Length should be 0 when no memory has been requested");
+        }
+
+        [Test]
+        public void GetReadOnlySequence_ShouldMatchMemoryRequestsAndTotalLength()
+        {
+            using var buffer = new PooledSequence();
+
+            var sizes = new[] { 3, 0, 5, 2 };
+            var expectedSegments = new byte[sizes.Length][];
+            var expectedTotalLength = 0;
+
+            for (int i = 0; i < sizes.Length; i++)
+            {
+                var size = sizes[i];
+                var mem = buffer.GetMemory(size);
+                var data = Enumerable.Range(i + 1, size).Select(x => (byte)x).ToArray();
+                data.CopyTo(mem);
+                expectedSegments[i] = data;
+                expectedTotalLength += size;
+            }
+
+            var sequence = buffer.GetReadOnlySequence();
+
+            // Direct comparison between buffer.Length and sequence.Length
+            Assert.That(sequence.Length, Is.EqualTo(buffer.Length), "Sequence length should match buffer.Length");
+
+            // Validate total length
+            Assert.That(sequence.Length, Is.EqualTo(expectedTotalLength), "Sequence length mismatch");
+            Assert.That(buffer.Length, Is.EqualTo(expectedTotalLength), "Buffer.Length mismatch");
+
+            // Validate segment structure
+            var segments = new List<ReadOnlyMemory<byte>>();
+            var position = sequence.Start;
+
+            while (sequence.TryGet(ref position, out var memory))
+            {
+                segments.Add(memory);
+            }
+
+            Assert.That(segments.Count, Is.EqualTo(sizes.Length), "Segment count mismatch");
+
+            for (int i = 0; i < sizes.Length; i++)
+            {
+                var segment = segments[i];
+                var expected = expectedSegments[i];
+
+                Assert.That(segment.Length, Is.EqualTo(expected.Length), $"Segment {i} length mismatch");
+                Assert.That(segment.ToArray(), Is.EqualTo(expected), $"Segment {i} data mismatch");
+            }
+        }
+
+        [Test]
+        public void Clear_ShouldDisposeBuffersAndResetState()
+        {
+            using var buffer = new PooledSequence();
+
+            // Add some buffers
+            buffer.GetMemory(4).Span.Fill(1);
+            buffer.GetMemory(6).Span.Fill(2);
+
+            Assert.That(buffer.Length, Is.EqualTo(10), "Precondition failed: Length should be 10");
+
+            // Clear the buffer
+            buffer.Clear();
+
+            // Validate state after clearing
+            Assert.That(buffer.Length, Is.EqualTo(0), "Length should be reset to 0 after Clear()");
+            Assert.That(buffer.GetReadOnlySequence().IsEmpty, Is.True, "Sequence should be empty after Clear()");
+
+            // Add new memory after clearing
+            var mem = buffer.GetMemory(3);
+            mem.Span.Fill(9);
+
+            Assert.That(buffer.Length, Is.EqualTo(3), "Length should reflect new memory after Clear()");
+            Assert.That(buffer.GetReadOnlySequence().ToArray(), Is.EqualTo(new byte[] { 9, 9, 9 }));
+        }
+
+        [Test]
+        public void Clone_ShouldCreateIndependentCopyWithSameContentAndLength()
+        {
+            using var original = new PooledSequence();
+
+            // Write distinct data to original buffer
+            var mem1 = original.GetMemory(3);
+            var mem2 = original.GetMemory(2);
+            mem1.Span[0] = 10;
+            mem1.Span[1] = 20;
+            mem1.Span[2] = 30;
+            mem2.Span[0] = 40;
+            mem2.Span[1] = 50;
+
+            var originalData = original.GetReadOnlySequence().ToArray();
+            var originalLength = original.Length;
+
+            // Clone the buffer
+            using var clone = original.Clone();
+
+            // Validate content and length
+            Assert.That(clone.Length, Is.EqualTo(originalLength), "Clone should have same length as original");
+            Assert.That(clone.GetReadOnlySequence().ToArray(), Is.EqualTo(originalData), "Clone should have same content as original");
+
+            // Modify original and ensure clone is unaffected
+            mem1.Span.Fill(99);
+            var modifiedOriginal = original.GetReadOnlySequence().ToArray();
+            var cloneData = clone.GetReadOnlySequence().ToArray();
+
+            Assert.That(cloneData, Is.Not.EqualTo(modifiedOriginal), "Clone should not reflect changes to original");
+        }
+
+        [Test]
+        public void CopyTo_ShouldCopyAllDataIntoDestinationSpan()
+        {
+            using var buffer = new PooledSequence();
+
+            buffer.GetMemory(3).Span.Fill(1);
+            buffer.GetMemory(2).Span.Fill(2);
+
+            var destination = new byte[5];
+            buffer.CopyTo(destination);
+
+            Assert.That(destination, Is.EqualTo(new byte[] { 1, 1, 1, 2, 2 }));
+        }
+
+        [Test]
+        public void CopyTo_ShouldThrowIfDestinationTooSmall()
+        {
+            using var buffer = new PooledSequence();
+            buffer.GetMemory(4).Span.Fill(9);
+
+            var destination = new byte[3]; // Too small
+
+            Assert.Throws<ArgumentException>(() => buffer.CopyTo(destination));
+        }
+
+        [Test]
+        public void CopyTo_ShouldThrowIfDisposed()
+        {
+            var buffer = new PooledSequence();
+            buffer.GetMemory(2);
+            buffer.Dispose();
+
+            var destination = new byte[2];
+            Assert.Throws<ObjectDisposedException>(() => buffer.CopyTo(destination));
+        }
+    }
+}

--- a/RTSP/MulticastUdpSocket.cs
+++ b/RTSP/MulticastUdpSocket.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Rtsp
 {

--- a/RTSP/RTSPHttpTransport.cs
+++ b/RTSP/RTSPHttpTransport.cs
@@ -1,6 +1,8 @@
 ﻿using Rtsp.Messages;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
@@ -22,12 +24,15 @@ namespace Rtsp
             private readonly string _sessionCookie = Guid.NewGuid().ToString("N")[..10];
             private readonly RtspHttpTransport _parent;
             private TcpClient? _outClient;
-            private readonly MemoryStream _sendBuffer = new();
+            private readonly PooledBufferWriter _sendBuffer;
+            private readonly MemoryPool<byte> _memoryPool;
 
-            public HttpTransportStream(RtspHttpTransport parent)
+            public HttpTransportStream(RtspHttpTransport parent, MemoryPool<byte>? memoryPool = null)
             {
                 _inStream = parent._dataClient!.GetStream();
                 _parent = parent;
+                _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+                _sendBuffer = new(_memoryPool);
             }
 
             internal bool Open()
@@ -95,7 +100,10 @@ namespace Rtsp
                     _outClient = new TcpClient();
                     _outClient.Connect(_parent._uri.Host, _parent._uri.Port);
 
-                    string base64CodedCommandString = Convert.ToBase64String(_sendBuffer.ToArray());
+                    // TODO: optimize this to use Base64.EncodeToUtf8InPlace(Span<Byte>, Int32, Int32) Method
+                    byte[] bytes = new byte[_sendBuffer.Length];
+                    _sendBuffer.CopyTo(bytes);
+                    string base64CodedCommandString = Convert.ToBase64String(bytes);
                     byte[] base64CommandBytes = Encoding.ASCII.GetBytes(base64CodedCommandString);
 
                     string request = _parent.ComposePostRequest(_sessionCookie, base64CommandBytes);
@@ -106,17 +114,31 @@ namespace Rtsp
                 }
                 else
                 {
-                    string base64CodedCommandString = Convert.ToBase64String(_sendBuffer.ToArray());
-                    byte[] base64CommandBytes = Encoding.ASCII.GetBytes(base64CodedCommandString);
-                    _outClient.GetStream().Write(base64CommandBytes);
+                    int originalLength = _sendBuffer.Length;
+                    int maxEncodedLength = Base64.GetMaxEncodedToUtf8Length(originalLength);
+
+                    // Rent a buffer large enough for both input and encoded output
+                    using IMemoryOwner<byte> memoryOwner = _memoryPool.Rent(maxEncodedLength);
+                    Span<byte> buffer = memoryOwner.Memory.Span.Slice(0, maxEncodedLength);
+
+                    // Copy original data to the end of the buffer
+                    int inputOffset = maxEncodedLength - originalLength;
+                    _sendBuffer.CopyTo(buffer.Slice(inputOffset, originalLength));
+
+                    // Encode in-place
+                    if (Base64.EncodeToUtf8InPlace(buffer, originalLength, out int bytesWritten) != OperationStatus.Done)
+                    {
+                        throw new InvalidOperationException("Base64 encoding failed.");
+                    }
+                    _outClient.GetStream().Write(buffer.Slice(0, bytesWritten));
                 }
 
-                _sendBuffer.SetLength(0);
+                _sendBuffer.Clear();
             }
 
             public override int Read(byte[] buffer, int offset, int count) => _inStream.Read(buffer, offset, count);
 
-            public override void Write(byte[] buffer, int offset, int count) => _sendBuffer.Write(buffer, offset, count);
+            public override void Write(byte[] buffer, int offset, int count) => _sendBuffer.Write(buffer.AsSpan(offset, count));
 
             private static int ReadUntilEndOfHeaders(Stream stream, byte[] buffer, int length)
             {

--- a/RTSP/Rtp/AACPayload.cs
+++ b/RTSP/Rtp/AACPayload.cs
@@ -1,4 +1,5 @@
 ﻿using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -9,6 +10,7 @@ namespace Rtsp.Rtp
     // It has methods to process the RTP Payload
 
     // (c) 2018 Roger Hardiman, RJH Technical Consultancy Ltd
+    // (c) 2023 Clemens Arth, Technology Consultant
 
     /*
     RFC 3640
@@ -120,8 +122,7 @@ namespace Rtsp.Rtp
             // Part 3 - Access Unit Audio Data
 
             // The rest of the RTP packet is the AMR data
-            List<ReadOnlyMemory<byte>> audioData = [];
-            List<IMemoryOwner<byte>> owners = [];
+            var buffer = new PooledSequence(_memoryPool);
 
             int position = 0;
             var rtpPayload = packet.Payload;
@@ -142,16 +143,13 @@ namespace Rtsp.Rtp
                 // extract the AAC block
                 if (position + aac_frame_size > rtpPayload.Length) break; // not enough data to copy
 
-                var owner = _memoryPool.Rent(aac_frame_size);
-                var data = owner.Memory[..aac_frame_size];
+                var data = buffer.GetMemory(aac_frame_size);
                 rtpPayload[position..(position + aac_frame_size)].CopyTo(data.Span);
-                owners.Add(owner);
-                audioData.Add(data);
 
                 position += aac_frame_size;
             }
 
-            return new(audioData, owners)
+            return new(buffer.GetReadOnlySequence(), buffer)
             {
                 RtpTimestamp = packet.Timestamp,
                 ClockTimestamp = RtpPacketOnvifUtils.ProcessRTPTimestampExtension(packet.Extension, headerPosition: out _),

--- a/RTSP/Rtp/AMRPayload.cs
+++ b/RTSP/Rtp/AMRPayload.cs
@@ -1,4 +1,5 @@
 ﻿using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -34,7 +35,7 @@ namespace Rtsp.Rtp
             // The rest of the RTP packet is the AMR data
             packet.Payload[1..].CopyTo(owner.Memory.Span);
 
-            return new([owner.Memory[..lenght]], [owner])
+            return new(new ReadOnlySequence<byte>(owner.Memory[..lenght]), owner)
             {
                 ClockTimestamp = RtpPacketOnvifUtils.ProcessRTPTimestampExtension(packet.Extension, headerPosition: out _),
                 RtpTimestamp = packet.Timestamp,

--- a/RTSP/Rtp/G711_1Payload.cs
+++ b/RTSP/Rtp/G711_1Payload.cs
@@ -1,4 +1,5 @@
 ﻿using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -10,11 +11,11 @@ namespace Rtsp.Rtp
     /// </summary>
     public class G711_1Payload : IPayloadProcessor
     {
-        private readonly MemoryPool<byte> _memoryPool;
+        private readonly MemoryPool<byte>? _memoryPool;
 
         public G711_1Payload(MemoryPool<byte>? memoryPool = null)
         {
-            _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+            _memoryPool = memoryPool;
         }
 
         public RawMediaFrame ProcessPacket(RtpPacket packet)
@@ -22,7 +23,7 @@ namespace Rtsp.Rtp
             // Look at the Header. This tells us the G711 mode being used
 
             // Mode Index (MI) is
-            // 1 - R1 40 octets containg Layer 0 data
+            // 1 - R1 40 octets containing Layer 0 data
             // 2 - R2a 50 octets containing Layer 0 plus Layer 1 data
             // 3 - R2b 50 octets containing Layer 0 plus Layer 2 data
             // 4 - R3 60 octets containing Layer 0 plus Layer 1 plus Layer 2 data
@@ -43,23 +44,18 @@ namespace Rtsp.Rtp
                 return RawMediaFrame.Empty;
             }
 
-            List<ReadOnlyMemory<byte>> audioDatas = [];
-            List<IMemoryOwner<byte>> owners = [];
-
+            var memoryPool = new PooledSequence(_memoryPool);
             // Extract each audio frame and place in the audio_data List
             int frame_start = 1; // starts just after the MI header
             while (frame_start + sizeOfOneFrame < rtpPayload.Length)
             {
                 // Return just the basic u-Law or A-Law audio (the Layer 0 audio)
-                var owner = _memoryPool.Rent(40);
-                owners.Add(owner);
-                var memory = owner.Memory[..40];
+                var memory = memoryPool.GetMemory(40);
                 // only copy the Layer 0 data (the first 40 bytes)
                 rtpPayload[frame_start..(frame_start + 40)].CopyTo(memory.Span);
-                audioDatas.Add(memory);
                 frame_start += sizeOfOneFrame;
             }
-            return new(audioDatas, owners)
+            return new(memoryPool.GetReadOnlySequence(), memoryPool)
             {
                 ClockTimestamp = RtpPacketOnvifUtils.ProcessRTPTimestampExtension(packet.Extension, headerPosition: out _),
                 RtpTimestamp = packet.Timestamp,

--- a/RTSP/Rtp/H264Payload.cs
+++ b/RTSP/Rtp/H264Payload.cs
@@ -1,12 +1,11 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 
 namespace Rtsp.Rtp
 {
@@ -21,18 +20,17 @@ namespace Rtsp.Rtp
         int norm, fu_a, fu_b, stap_a, stap_b, mtap16, mtap24; // used for diagnostics stats
 
         // Stores the NAL units for a Video Frame. May be more than one NAL unit in a video frame.
-        private readonly List<ReadOnlyMemory<byte>> nalUnits = [];
-        private readonly List<IMemoryOwner<byte>> owners = [];
+        private readonly PooledSequence nalUnitsBuffer;
         // used to concatenate fragmented H264 NALs where NALs are split over RTP packets
-        private readonly MemoryStream fragmentedNal = new();
-        private readonly MemoryPool<byte> _memoryPool;
+        private readonly PooledBufferWriter fragmentedNal;
 
         private DateTime _timestamp;
 
         public H264Payload(ILogger<H264Payload>? logger, MemoryPool<byte>? memoryPool = null)
         {
             _logger = logger as ILogger ?? NullLogger.Instance;
-            _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+            fragmentedNal = new(memoryPool);
+            nalUnitsBuffer = new(memoryPool);
         }
 
         // Process a RTP Packet.
@@ -114,15 +112,17 @@ namespace Rtsp.Rtp
                 if (fu_header_s == 1 && fu_header_e == 0)
                 {
                     // Start of Fragment.
-                    // Initiise the fragmented_nal byte array
+                    // Initializes the fragmented_nal byte array
                     // Build the NAL header with the original F and NRI flags but use the the Type field from the fu_header_type
                     byte reconstructed_nal_type = (byte)((nal_header_f_bit << 7) + (nal_header_nri << 5) + fu_header_type);
 
                     // Empty the stream
-                    fragmentedNal.SetLength(0);
+                    fragmentedNal.Clear();
+
+                    var buffer = fragmentedNal.GetMemory(1 + 1 + payload.Length - 2).Span;
 
                     // Add reconstructed_nal_type byte to the memory stream
-                    fragmentedNal.WriteByte(reconstructed_nal_type);
+                    fragmentedNal.Write(reconstructed_nal_type);
 
                     // copy the rest of the RTP payload to the memory stream
                     fragmentedNal.Write(payload[2..]);
@@ -146,7 +146,7 @@ namespace Rtsp.Rtp
                     // Add the NAL to the array of NAL units
                     var length = (int)fragmentedNal.Length;
                     var nalSpan = PrepareNewNal(length);
-                    fragmentedNal.GetBuffer().AsSpan()[..length].CopyTo(nalSpan);
+                    fragmentedNal.CopyTo(nalSpan);
                 }
             }
             else if (nal_header_type == 29)
@@ -162,10 +162,8 @@ namespace Rtsp.Rtp
 
         private Span<byte> PrepareNewNal(int sizeWitoutHeader)
         {
-            var owner = _memoryPool.Rent(sizeWitoutHeader + 4);
-            owners.Add(owner);
-            var memory = owner.Memory[..(sizeWitoutHeader + 4)];
-            nalUnits.Add(memory);
+            int size = sizeWitoutHeader + 4;
+            var memory = nalUnitsBuffer.GetMemory(size);
             // Add the NAL start code 00 00 00 01
             memory.Span[0] = 0;
             memory.Span[1] = 0;
@@ -195,16 +193,13 @@ namespace Rtsp.Rtp
 
             // End Marker is set return the list of NALs
             // clone list of nalUnits and owners
-            var result = new RawMediaFrame(
-                new List<ReadOnlyMemory<byte>>(nalUnits),
-                new List<IMemoryOwner<byte>>(owners)
-                )
+            var data = nalUnitsBuffer.Clone();
+            var result = new RawMediaFrame(data.GetReadOnlySequence(), data)
             {
                 RtpTimestamp = packet.Timestamp,
                 ClockTimestamp = _timestamp,
             };
-            nalUnits.Clear();
-            owners.Clear();
+            nalUnitsBuffer.Clear();
             return result;
         }
     }

--- a/RTSP/Rtp/H265Payload.cs
+++ b/RTSP/Rtp/H265Payload.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
@@ -26,11 +27,9 @@ namespace Rtsp.Rtp
 
         private readonly bool hasDonl;
 
-        private readonly List<ReadOnlyMemory<byte>> nals = [];
-        private readonly List<IMemoryOwner<byte>> owners = [];
+        private readonly PooledSequence nalsBuffer;
         // used to concatenate fragmented NALs where NALs are split over RTP packets
-        private readonly MemoryStream fragmentedNal = new();
-        private readonly MemoryPool<byte> _memoryPool;
+        private readonly PooledBufferWriter fragmentedNal;
 
         private DateTime _timestamp;
 
@@ -40,7 +39,8 @@ namespace Rtsp.Rtp
             this.hasDonl = hasDonl;
 
             _logger = logger as ILogger ?? NullLogger.Instance;
-            _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+            fragmentedNal = new(memoryPool);
+            nalsBuffer = new(memoryPool);
         }
 
         /// <summary>
@@ -118,13 +118,13 @@ namespace Rtsp.Rtp
                 // Initiise the fragmented_nal byte array
 
                 // Empty the stream
-                fragmentedNal.SetLength(0);
+                fragmentedNal.Clear();
 
                 // Reconstrut the NAL header from the rtp_payload_header, replacing the Type with FU Type
                 int nal_header = payloadHeader & 0x81FF; // strip out existing 'type'
                 nal_header |= fu_header_type << 9;
-                fragmentedNal.WriteByte((byte)(nal_header >> 8 & 0xFF));
-                fragmentedNal.WriteByte((byte)(nal_header >> 0 & 0xFF));
+                fragmentedNal.Write((byte)(nal_header >> 8 & 0xFF));
+                fragmentedNal.Write((byte)(nal_header >> 0 & 0xFF));
             }
 
             // Part of Fragment
@@ -146,7 +146,7 @@ namespace Rtsp.Rtp
                 // Add the NAL to the array of NAL units
                 var length = (int)fragmentedNal.Length;
                 var nalSpan = PrepareNewNal(length);
-                fragmentedNal.GetBuffer().AsSpan()[..length].CopyTo(nalSpan);
+                fragmentedNal.CopyTo(nalSpan);
             }
         }
 
@@ -183,10 +183,7 @@ namespace Rtsp.Rtp
 
         private Span<byte> PrepareNewNal(int sizeWitoutHeader)
         {
-            var owner = _memoryPool.Rent(sizeWitoutHeader + 4);
-            owners.Add(owner);
-            var memory = owner.Memory[..(sizeWitoutHeader + 4)];
-            nals.Add(memory);
+            var memory = nalsBuffer.GetMemory(sizeWitoutHeader + 4);
             // Add the NAL start code 00 00 00 01
             memory.Span[0] = 0;
             memory.Span[1] = 0;
@@ -212,15 +209,13 @@ namespace Rtsp.Rtp
 
             // End Marker is set return the list of NALs
             // clone list of nalUnits and owners
-            var result = new RawMediaFrame(
-                new List<ReadOnlyMemory<byte>>(nals),
-                new List<IMemoryOwner<byte>>(owners))
+            var data = nalsBuffer.Clone();
+            var result = new RawMediaFrame(data.GetReadOnlySequence(), data)
             {
                 RtpTimestamp = packet.Timestamp,
                 ClockTimestamp = _timestamp,
             };
-            nals.Clear();
-            owners.Clear();
+            nalsBuffer.Clear();
             return result;
         }
     }

--- a/RTSP/Rtp/JPEGPayload.cs
+++ b/RTSP/Rtp/JPEGPayload.cs
@@ -1,4 +1,5 @@
 ﻿using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
@@ -23,7 +24,7 @@ namespace Rtsp.Rtp
         const int JPEG_HEADER_SIZE = 8;
         const int JPEG_MAX_SIZE = 16 * 1024 * 1024;
 
-        private readonly MemoryStream _frameStream = new(64 * 1024);
+        private readonly PooledBufferWriter _frameBuffer;
         private readonly MemoryPool<byte> _memoryPool;
         private int _currentDri;
         private int _currentQ;
@@ -46,6 +47,7 @@ namespace Rtsp.Rtp
         public JPEGPayload(MemoryPool<byte>? memoryPool = null)
         {
             _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+            _frameBuffer = new(_memoryPool);
         }
 
         public RawMediaFrame ProcessPacket(RtpPacket packet)
@@ -63,17 +65,17 @@ namespace Rtsp.Rtp
             }
             ProcessJPEGRTPFrame(packet.Payload);
 
-            if (!packet.IsMarker || _frameStream.Length == 0)
+            if (!packet.IsMarker || _frameBuffer.Length == 0)
             {
                 // we don't have a frame yet. Keep accumulating RTP packets
                 return RawMediaFrame.Empty;
             }
             // End Marker is set. The frame is complete
-            var length = (int)_frameStream.Length;
+            var length = (int)_frameBuffer.Length;
             var memoryOwner = _memoryPool.Rent(length);
-            _frameStream.GetBuffer().AsSpan()[..length].CopyTo(memoryOwner.Memory.Span);
-            _frameStream.SetLength(0);
-            return new RawMediaFrame([memoryOwner.Memory[..length]], [memoryOwner])
+            _frameBuffer.CopyTo(memoryOwner.Memory.Span);
+            _frameBuffer.Clear();
+            return new RawMediaFrame(new ReadOnlySequence<byte>(memoryOwner.Memory.Slice(0, length)), memoryOwner)
             {
                 RtpTimestamp = packet.Timestamp,
                 ClockTimestamp = _timestamp ?? DateTime.MinValue,
@@ -148,16 +150,16 @@ namespace Rtsp.Rtp
                     ReInitializeJpegHeader();
                 }
 
-                _frameStream.Write(_jpegHeaderBytes, 0, _jpegHeaderBytes.Length);
+                _frameBuffer.Write(_jpegHeaderBytes.AsSpan());
             }
 
-            if (fragmentOffset != 0 && _frameStream.Position == 0) { return false; }
-            if (_frameStream.Position > JPEG_MAX_SIZE) { return false; }
+            if (fragmentOffset != 0 && _frameBuffer.Length == 0) { return false; }
+            if (_frameBuffer.Length > JPEG_MAX_SIZE) { return false; }
 
             int dataSize = payload.Length - offset;
             if (dataSize < 0) { return false; }
 
-            _frameStream.Write(payload[offset..]);
+            _frameBuffer.Write(payload[offset..]);
 
             return true;
         }

--- a/RTSP/Rtp/RawMediaFrame.cs
+++ b/RTSP/Rtp/RawMediaFrame.cs
@@ -8,10 +8,10 @@ namespace Rtsp.Rtp
     public class RawMediaFrame : IDisposable
     {
         private bool disposedValue;
-        private readonly IEnumerable<ReadOnlyMemory<byte>> _data;
-        private readonly IEnumerable<IMemoryOwner<byte>> _owners;
+        private readonly ReadOnlySequence<byte> _data;
+        private readonly IDisposable? _memoryOwner;
 
-        public IEnumerable<ReadOnlyMemory<byte>> Data
+        public ReadOnlySequence<byte> Data
         {
             get
             {
@@ -23,13 +23,13 @@ namespace Rtsp.Rtp
         public required DateTime ClockTimestamp { get; init; }
         public required uint RtpTimestamp { get; init; }
 
-        public RawMediaFrame(IEnumerable<ReadOnlyMemory<byte>> data, IEnumerable<IMemoryOwner<byte>> owners)
+        public RawMediaFrame(ReadOnlySequence<byte> data, IDisposable? memoryOwner)
         {
             _data = data;
-            _owners = owners;
+            _memoryOwner = memoryOwner;
         }
 
-        public bool Any() => Data.Any();
+        public bool Any() => !Data.IsEmpty;
 
         protected virtual void Dispose(bool disposing)
         {
@@ -37,10 +37,7 @@ namespace Rtsp.Rtp
             {
                 if (disposing)
                 {
-                    foreach (var owner in _owners)
-                    {
-                        owner.Dispose();
-                    }
+                    _memoryOwner?.Dispose();
                 }
                 disposedValue = true;
             }
@@ -52,6 +49,6 @@ namespace Rtsp.Rtp
             GC.SuppressFinalize(this);
         }
 
-        public static RawMediaFrame Empty => new([], []) { RtpTimestamp = 0, ClockTimestamp = DateTime.MinValue };
+        public static RawMediaFrame Empty => new(ReadOnlySequence<byte>.Empty, null) { RtpTimestamp = 0, ClockTimestamp = DateTime.MinValue };
     }
 }

--- a/RTSP/Rtp/RawPayload.cs
+++ b/RTSP/Rtp/RawPayload.cs
@@ -1,4 +1,5 @@
 ﻿using Rtsp.Onvif;
+using Rtsp.Utils;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -11,15 +12,14 @@ namespace Rtsp.Rtp
 
         public RawPayload(MemoryPool<byte>? memoryPool = null)
         {
-            _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+            _memoryPool = memoryPool ??= MemoryPool<byte>.Shared;
         }
 
         public RawMediaFrame ProcessPacket(RtpPacket packet)
         {
-            var owner = _memoryPool.Rent(packet.PayloadSize);
-            var memory = owner.Memory[..packet.PayloadSize];
-            packet.Payload.CopyTo(memory.Span);
-            return new RawMediaFrame([memory], [owner])
+            var memoryOwner = _memoryPool.Rent(packet.PayloadSize);
+            packet.Payload.CopyTo(memoryOwner.Memory.Span);
+            return new RawMediaFrame(new ReadOnlySequence<byte>(memoryOwner.Memory.Slice(0, (packet.PayloadSize))), memoryOwner)
             {
                 ClockTimestamp = RtpPacketOnvifUtils.ProcessRTPTimestampExtension(packet.Extension, headerPosition: out _),
                 RtpTimestamp = packet.Timestamp,

--- a/RTSP/Utils/PooledBufferWriter.cs
+++ b/RTSP/Utils/PooledBufferWriter.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace Rtsp.Utils;
+
+/// <summary>
+/// A pooled buffer writer that implements <see cref="IBufferWriter{Byte}"/>,
+/// backed by segments rented from a <see cref="MemoryPool{Byte}"/>.
+/// </summary>
+internal sealed class PooledBufferWriter : IBufferWriter<byte>, IDisposable
+{
+    private readonly MemoryPool<byte> _memoryPool;
+    private readonly List<IMemoryOwner<byte>> _owners = new();
+
+    private IMemoryOwner<byte>? _currentOwner;
+    private Memory<byte> _currentMemory;
+    private int _currentIndex;
+
+    /// <summary>
+    /// Gets the total number of bytes written to the buffer.
+    /// </summary>
+    public int Length { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PooledBufferWriter"/> class.
+    /// </summary>
+    /// <param name="memoryPool">An optional memory pool to use. Defaults to <see cref="MemoryPool{Byte}.Shared"/>.</param>
+    public PooledBufferWriter(MemoryPool<byte>? memoryPool = null)
+    {
+        _memoryPool = memoryPool ?? MemoryPool<byte>.Shared;
+    }
+
+    /// <summary>
+    /// Clears the buffer, returning all rented memory segments to the pool.
+    /// </summary>
+    public void Clear()
+    {
+        foreach (var owner in _owners)
+        {
+            owner.Dispose();
+        }
+
+        _owners.Clear();
+
+        if (_currentOwner != null)
+        {
+            _currentOwner.Dispose();
+            _currentOwner = null;
+        }
+
+        _currentMemory = default;
+        _currentIndex = 0;
+        Length = 0;
+    }
+
+    /// <summary>
+    /// Copies the written data to the specified destination span.
+    /// </summary>
+    /// <param name="destination">The span to copy data into.</param>
+    /// <exception cref="ArgumentException">Thrown if the destination span is too small.</exception>
+    public void CopyTo(Span<byte> destination)
+    {
+        if (destination.Length < Length)
+        {
+            throw new ArgumentException("Destination span is too small.", nameof(destination));
+        }
+
+        int copied = 0;
+
+        foreach (var owner in _owners)
+        {
+            var span = owner.Memory.Span;
+            span.CopyTo(destination.Slice(copied));
+            copied += span.Length;
+        }
+
+        if (_currentIndex > 0)
+        {
+            _currentMemory.Span.Slice(0, _currentIndex).CopyTo(destination.Slice(copied));
+        }
+    }
+
+    /// <summary>
+    /// Writes a single byte to the buffer.
+    /// </summary>
+    /// <param name="value">The byte to write.</param>
+    public void Write(byte value)
+    {
+        EnsureCapacity(1);
+        _currentMemory.Span[_currentIndex] = value;
+        Advance(1);
+    }
+
+    /// <summary>
+    /// Writes a span of bytes to the buffer.
+    /// </summary>
+    /// <param name="source">The span of bytes to write.</param>
+    public void Write(ReadOnlySpan<byte> source)
+    {
+        var offset = 0;
+
+        while (offset < source.Length)
+        {
+            EnsureCapacity(1); // Ensure at least one byte is available
+            int writable = Math.Min(_currentMemory.Length - _currentIndex, source.Length - offset);
+            source.Slice(offset, writable).CopyTo(_currentMemory.Span.Slice(_currentIndex));
+            Advance(writable);
+            offset += writable;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Advance(int count)
+    {
+        if (count < 0 || count > _currentMemory.Length - _currentIndex)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count));
+        }
+
+        _currentIndex += count;
+        Length += count;
+    }
+
+    /// <inheritdoc />
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _currentMemory.Slice(_currentIndex);
+    }
+
+    /// <inheritdoc />
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        return GetMemory(sizeHint).Span;
+    }
+
+    /// <summary>
+    /// Ensures the current buffer has at least the specified capacity available.
+    /// If not, commits the current buffer and rents a new one.
+    /// </summary>
+    /// <param name="sizeHint">The minimum number of bytes required.</param>
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (_currentMemory.Length - _currentIndex < sizeHint)
+        {
+            if (_currentOwner != null)
+            {
+                _owners.Add(_currentOwner);
+                _currentOwner = null;
+            }
+
+            var bufferSize = Math.Max(sizeHint, 4096);
+            _currentOwner = _memoryPool.Rent(bufferSize);
+            _currentMemory = _currentOwner.Memory;
+            _currentIndex = 0;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the buffer writer and returns all rented memory to the pool.
+    /// </summary>
+    public void Dispose()
+    {
+        Clear();
+    }
+}

--- a/RTSP/Utils/PooledSequence.cs
+++ b/RTSP/Utils/PooledSequence.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Rtsp.Utils;
+
+/// <summary>
+/// A pooled memory buffer backed by a <see cref="MemoryPool{T}.Shared"/> of <see langword="byte"/> for efficient writing of byte data and
+/// allows reading the written content through a <see cref="ReadOnlySequence{Byte}"/> using the <see cref="GetReadOnlySequence"/> method.
+/// </summary>
+internal sealed class PooledSequence : IDisposable
+{
+    private readonly List<(ReadOnlyMemory<byte> memory, IDisposable memoryOwner)> _buffers = new();
+    private readonly MemoryPool<byte> _pool;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PooledSequence"/> class with an optional initial buffer size and array pool.
+    /// </summary>
+    /// <param name="initialBufferSize">The initial size of the buffer to rent from the pool. Defaults to 4096 bytes.</param>
+    /// <param name="pool">The array pool to use. If null, <see cref="MemoryPool{T}.Shared"/> of <see langword="byte"/> is used.</param>
+    public PooledSequence(MemoryPool<byte>? pool = null)
+    {
+        _pool = pool ?? MemoryPool<byte>.Shared;
+    }
+
+    /// <summary>
+    /// The total length of all rented buffers in bytes.
+    /// </summary>
+    public int Length { get; private set; }
+
+    /// <summary>
+    /// Rents a writable memory buffer of the specified size.
+    /// </summary>
+    /// <param name="size">The size of the memory buffer to rent, in bytes.</param>
+    /// <returns>A writable <see cref="Memory{byte}"/> buffer.</returns>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown if the buffer has already been disposed.
+    /// </exception>
+    public Memory<byte> GetMemory(int size)
+    {
+        EnsureNotDisposed();
+
+        var memoryOwner = _pool.Rent(size);
+        var memory = memoryOwner.Memory.Slice(0, size);
+        _buffers.Add((memory, memoryOwner));
+        Length += size;
+
+        return memory;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="ReadOnlySequence{Byte}"/> representing the written data across all buffers.
+    /// </summary>
+    /// <returns>A read-only sequence of bytes.</returns>
+    public ReadOnlySequence<byte> GetReadOnlySequence()
+    {
+        EnsureNotDisposed();
+
+        SequenceSegment? first = null;
+        SequenceSegment? last = null;
+
+        for (var i = 0; i < _buffers.Count; i++)
+        {
+            var (buffer, _) = _buffers[i];
+
+            var segment = new SequenceSegment(buffer);
+
+            if (first == null)
+            {
+                first = segment;
+            }
+
+            if (last != null)
+            {
+                last.SetNext(segment);
+            }
+
+            last = segment;
+        }
+
+        if (first == null || last == null)
+        {
+            return ReadOnlySequence<byte>.Empty;
+        }
+
+        return new ReadOnlySequence<byte>(first, 0, last, last.Memory.Length);
+    }
+
+    /// <summary>
+    /// Clears the buffer and resets the internal state of the object.
+    /// </summary>
+    public void Clear()
+    {
+        EnsureNotDisposed();
+
+        foreach (var (_, memoryOwner) in _buffers)
+        {
+            memoryOwner.Dispose();
+        }
+
+        _buffers.Clear();
+        Length = 0;
+    }
+
+
+    /// <summary>
+    /// Creates a deep copy of the current <see cref="PooledSequence"/> instance,
+    /// including all written data up to the current write position.
+    /// </summary>
+    /// <returns>
+    /// A new <see cref="PooledSequence"/> instance containing a copy of the data
+    /// from the original buffer. The cloned instance has its own rented buffers and
+    /// maintains the same write position as the original.
+    /// </returns>
+
+    public PooledSequence Clone()
+    {
+        EnsureNotDisposed();
+
+        var clone = new PooledSequence();
+
+        foreach (var (buffer, _) in _buffers)
+        {
+            buffer.CopyTo(clone.GetMemory(buffer.Length));
+        }
+
+        return clone;
+    }
+
+    /// <summary>
+    /// Copies the contents of the buffer into the provided destination span.
+    /// </summary>
+    /// <param name="destination">The span to copy the data into.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the destination span is smaller than the total buffer length.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown if the buffer has been disposed.
+    /// </exception>
+    public void CopyTo(Span<byte> destination)
+    {
+        EnsureNotDisposed();
+
+        if (destination.Length < Length)
+            throw new ArgumentException("Destination span is too small.", nameof(destination));
+
+        foreach (var (memory, _) in _buffers)
+        {
+            memory.Span.CopyTo(destination);
+            destination = destination.Slice(memory.Length);
+        }
+    }
+
+    /// <summary>
+    /// Releases all buffers back to the pool and clears internal state.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        Clear();
+        _disposed = true;
+    }
+
+
+#if NET8_0_OR_GREATER
+    [StackTraceHidden]
+#endif
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureNotDisposed()
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(_disposed, this);
+#else
+        if (_disposed)
+        {
+            ThrowObjectDisposedException();
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static void ThrowObjectDisposedException() => throw new ObjectDisposedException(typeof(PooledSequence).FullName);
+        }
+#endif
+    }
+
+    private class SequenceSegment : ReadOnlySequenceSegment<byte>
+    {
+        public SequenceSegment(ReadOnlyMemory<byte> memory)
+        {
+            Memory = memory;
+        }
+
+        public void SetNext(SequenceSegment next)
+        {
+            Next = next;
+            next.RunningIndex = RunningIndex + Memory.Length;
+        }
+    }
+}

--- a/RtspClientExample/RTSPEventArgs.cs
+++ b/RtspClientExample/RTSPEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 
 namespace RtspClientExample
@@ -40,13 +41,13 @@ namespace RtspClientExample
 
     public class SimpleDataEventArgs : EventArgs
     {
-        public SimpleDataEventArgs(IEnumerable<ReadOnlyMemory<byte>> data, DateTime timeStamp)
+        public SimpleDataEventArgs(ReadOnlySequence<byte> data, DateTime timeStamp)
         {
             Data = data;
             TimeStamp = timeStamp;
         }
 
         public DateTime TimeStamp { get; }
-        public IEnumerable<ReadOnlyMemory<byte>> Data { get; }
+        public ReadOnlySequence<byte> Data { get; }
     }
 }


### PR DESCRIPTION
### 🛠️ Introduce Efficient Buffer Writer with ReadOnlySequence Access

#### 📌 Summary

This PR introduces a new class that implements `IBufferWriter<byte>` and provides a `GetReadOnlySequence()` method to expose the written data as a `ReadOnlySequence<byte>`. This replaces the previous approach of using `IEnumerable<ReadOnlyMemory<byte>>` for representing sequences of byte buffers.

#### ✅ Why This Change?

The new design offers **significant performance and usability improvements** over the previous `IEnumerable<ReadOnlyMemory<byte>>` approach:

---

### 🚀 Benefits of `IBufferWriter<byte>` + `ReadOnlySequence<byte>`

1. **Zero-Copy Efficiency**  
   As the current implementation using `IEnumerable<ReadOnlyMemory<byte>>`, `ReadOnlySequence<byte>` is designed for high-performance scenarios. It allows consumers to traverse a sequence of memory segments without copying data, which is ideal for parsers, serializers, and network protocols.

2. **Better Interoperability**  
   `ReadOnlySequence<byte>` is the standard input for many high-performance .NET APIs (e.g., `System.IO.Pipelines`, `System.Text.Json`, `System.Buffers`). This makes the new class more compatible with modern .NET libraries.

3. **Fine-Grained Control Over Memory**  
   `IBufferWriter<byte>` allows producers to write directly into pre-allocated buffers, reducing allocations and enabling better memory reuse.

4. **Improved Performance Characteristics**  
   - Avoids the overhead of enumerating `IEnumerable<ReadOnlyMemory<byte>>`.
   - Enables contiguous or segmented memory layouts with minimal overhead.
   - Supports pooling and span-based writing patterns.

5. **Cleaner API Surface**  
   The combination of `IBufferWriter<byte>` and `ReadOnlySequence<byte>` clearly separates the concerns of writing and reading, leading to more maintainable and testable code.
