### PR TITLE
Adding missing RTSP request type classes

### DIFF
--- a/RTSP.Tests/Messages/RTSPMessageTest.cs
+++ b/RTSP.Tests/Messages/RTSPMessageTest.cs
@@ -64,8 +64,10 @@ namespace Rtsp.Messages.Tests
         [GenericTestCase<RtspRequestPause>(RtspRequest.RequestType.PAUSE)]
         [GenericTestCase<RtspRequestTeardown>(RtspRequest.RequestType.TEARDOWN)]
         [GenericTestCase<RtspRequestGetParameter>(RtspRequest.RequestType.GET_PARAMETER)]
+        [GenericTestCase<RtspRequestSetParameter>(RtspRequest.RequestType.SET_PARAMETER)]
         [GenericTestCase<RtspRequestAnnounce>(RtspRequest.RequestType.ANNOUNCE)]
         [GenericTestCase<RtspRequestRecord>(RtspRequest.RequestType.RECORD)]
+        [GenericTestCase<RtspRequestRedirect>(RtspRequest.RequestType.REDIRECT)]
         public void CheckRequestType<T>(RtspRequest.RequestType expectedType) where T : RtspRequest, new()
         {
             RtspRequest onMessage = new T();

--- a/RTSP/Messages/RTSPRequest.cs
+++ b/RTSP/Messages/RTSPRequest.cs
@@ -54,12 +54,10 @@ namespace Rtsp.Messages
                 RequestType.PAUSE => new RtspRequestPause(),
                 RequestType.TEARDOWN => new RtspRequestTeardown(),
                 RequestType.GET_PARAMETER => new RtspRequestGetParameter(),
+                RequestType.SET_PARAMETER => new RtspRequestSetParameter(),
                 RequestType.ANNOUNCE => new RtspRequestAnnounce(),
                 RequestType.RECORD => new RtspRequestRecord(),
-                /*
                 RequestType.REDIRECT => new RtspRequestRedirect(),
-                RequestType.SET_PARAMETER => new RtspRequestSetParameter(),
-                */
                 _ => new RtspRequest(),
             };
         }

--- a/RTSP/Messages/RTSPRequestRedirect.cs
+++ b/RTSP/Messages/RTSPRequestRedirect.cs
@@ -1,0 +1,10 @@
+﻿namespace Rtsp.Messages
+{
+    public class RtspRequestRedirect : RtspRequest
+    {
+        public RtspRequestRedirect()
+        {
+            Command = "REDIRECT * RTSP/1.0";
+        }
+    }
+}

--- a/RTSP/Messages/RTSPRequestSetParameter.cs
+++ b/RTSP/Messages/RTSPRequestSetParameter.cs
@@ -1,0 +1,10 @@
+﻿namespace Rtsp.Messages
+{
+    public class RtspRequestSetParameter : RtspRequest
+    {
+        public RtspRequestSetParameter()
+        {
+            Command = "SET_PARAMETER * RTSP/1.0";
+        }
+    }
+}


### PR DESCRIPTION
Hello,

RTSP request types SET_PARAMETER and REDIRECT were left commented out.
This change adds the missing classes and their parsing.