### PR TITLE
Fixed loose reading media with attributes in mixed order #141

### DIFF
--- a/RTSP/Sdp/SdpFile.cs
+++ b/RTSP/Sdp/SdpFile.cs
@@ -306,10 +306,55 @@ namespace Rtsp.Sdp
                     case 'm':
                         while (value.Key == 'm')
                         {
-                            Media newMedia = ReadMedia(sdpStream, ref value);
+                            Media newMedia = ReadMediaLoose(sdpStream, ref value);
                             returnValue.Medias.Add(newMedia);
                         }
                         break;
+                }
+            }
+
+            return returnValue;
+        }
+
+        private static Media ReadMediaLoose(TextReader sdpStream, ref KeyValuePair<char, string> value)
+        {
+            Media returnValue = new(value.Value);
+
+            while (true)
+            {
+                value = GetKeyValue(sdpStream);
+
+                // Media title
+                if (value.Key == 'i')
+                {
+                }
+
+                // Connexion optional and multiple in media
+                else if (value.Key == 'c')
+                {
+                    returnValue.Connections.Add(Connection.Parse(value.Value));
+                }
+
+                // bandwidth optional multiple value possible
+                else if (value.Key == 'b')
+                {
+                    returnValue.Bandwidths.Add(Bandwidth.Parse(value.Value));
+                }
+
+                // encryption key optional
+                else if (value.Key == 'k')
+                {
+                    // Obsolete in RFC 8866 ignored
+                }
+
+                //Attribut optional multiple
+                else if (value.Key == 'a')
+                {
+                    returnValue.Attributs.Add(Attribut.ParseInvariant(value.Value));
+                }
+                else
+                {
+                    break;
                 }
             }
 


### PR DESCRIPTION
Fixes reading of the following SDP:
```
v=0
o=- 0 0 IN IP4 127.0.0.1
s=Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film
t=0 0
a=tool:libavformat 62.1.103
m=video 11111 RTP/AVP 96
a=control:trackID=0
c=IN IP4 127.0.0.1
b=AS:893
a=rtpmap:96 AV1/90000
a=fmtp:96 profile=0;level-idx=8;tier=0
m=audio 11113 RTP/AVP 97
a=control:trackID=1
c=IN IP4 127.0.0.1
b=AS:127
a=rtpmap:97 MPEG4-GENERIC/44100/2
a=fmtp:97 profile-level-id=1;mode=AAC-hbr;sizelength=13;indexlength=3;indexdeltalength=3; config=12100000000000000000000000000000
```

Added a second method ReadMediaLoose which ignores the order of the attributes that follow. 