### PR TITLE
Fix ReadOneMessageAsync(PipeReader) issue

### DIFF
--- a/RTSP.Tests/RTSPListenerTest.cs
+++ b/RTSP.Tests/RTSPListenerTest.cs
@@ -9,6 +9,8 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO.Pipelines;
+using System.Buffers;
 
 namespace Rtsp.Tests
 {
@@ -562,6 +564,35 @@ namespace Rtsp.Tests
             Assert.That(
                 () => testedListener.SendData(data.Channel, data.Data),
                 Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public async Task InterleavedDataHeaderSplitAcrossPipeSegments()
+        {
+            var payload = new byte[] { 1, 2, 3, 4, 5 };
+            var size = payload.Length;
+            byte channel = 7;
+
+            // Setup test object.
+            using var testedListener = new RtspListener(_mockTransport);
+
+            var reader = PipeReader.Create(
+                Utils.Tests.ReadOnlySequenceExtensionsTests.CreateSequence(
+                    [(byte)'$'],
+                    [channel, (byte)(size >> 8), (byte)(size & 0xFF)],
+                    payload));
+
+            var message = await testedListener.ReadOneMessageAsync(reader);
+            Assert.That(message, Is.Not.Null, "Message should be parsed correctly even with split header");
+            Assert.That(message, Is.InstanceOf<RtspData>());
+            
+            var dataMsg = (RtspData)message;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(dataMsg.Channel, Is.EqualTo(channel));
+                Assert.That(dataMsg.Data.Length, Is.EqualTo(payload.Length));
+                Assert.That(dataMsg.Data.ToArray(), Is.EqualTo(payload));
+            }
         }
     }
 }

--- a/RTSP.Tests/Utils/ReadOnlySequenceExtensionsTests.cs
+++ b/RTSP.Tests/Utils/ReadOnlySequenceExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace Rtsp.Utils.Tests
             }
         }
 
-        private static ReadOnlySequence<byte> CreateSequence(params byte[][] buffers)
+        internal static ReadOnlySequence<byte> CreateSequence(params byte[][] buffers)
         {
             var firstSegment = new TestSegment(buffers[0]);
             var lastSegment = firstSegment;

--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -343,8 +343,11 @@ namespace Rtsp
             {
                 if (buffer.Length < 4) return ReadingMessage.NotEnoughtData;
 
-                var channel = buffer.First.Span[1];
-                var size = BinaryPrimitives.ReadUInt16BigEndian(buffer.First.Span[2..]);
+                Span<byte> header = stackalloc byte[3];
+                buffer.Slice(1, 3).CopyTo(header);
+
+                var channel = header[0];
+                var size = BinaryPrimitives.ReadUInt16BigEndian(header[1..]);
                 if (buffer.Length < size + 4)
                     return ReadingMessage.NotEnoughtData;
 


### PR DESCRIPTION
I sometimes getting `IndexOutOfRangeException` exceptions during debug sessions using (`PipeReader`) overload when `PipeReader` wraps `NetworkStream`. 

How to reproduce: first segment of 4+ byte sequence only contains `$`.

This fixes interleaved data header parsing (no single-span assumption for the header)