### PR TITLE
Add support for SHA-256

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The source of the nuget package [SharpRTSP](https://www.nuget.org/packages/Sharp
 
 A C# library to build RTSP Clients, RTSP Servers and handle RTP data streams. The library has several examples.
 * RTSP Client Example - will connect to a RTSP server and receive Video and Audio in H264, H265/HEVC, G711, AAC and AMR formats. UDP, TCP and Multicast are supported. The data received is written to files.
-* RTSP Camera Server Example - A YUV Image Generator and a very simple H264 Encoder generate H264 NALs which are then delivered via a RTSP Server to clients
+* RTSP Camera Server Example - A YUV Image Generator and a very simple H264 Encoder generate H264 NALs which are then delivered via a RTSP Server to clients with MD5 and SHA256 Digest Options
 * RTP Receiver - will receieve RTP and RTCP packets and pass them to a transport handler
 * RTSP Server - will accept RTSP connections and talk to clients
 * RTP Sender - will send RTP packets to clients

--- a/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
+++ b/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
@@ -1,0 +1,98 @@
+﻿using NUnit.Framework;
+using Rtsp;
+using Rtsp.Messages;
+using System.Net;
+using System.Security;
+
+namespace RTSP.Tests.Authentication
+{
+    public class AuthenticationDigestTests
+    {
+        // MD5, no Algorithm specified
+        string authStringPLAY_MD5_noalg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"556284985\", uri=\"rtsp://192.168.26.76:8554/\", response=\"f3ce799d94cb45e14bf59e57cd41c749\"";
+        string authStringPLAY_MD5_with_alg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"556284985\", uri=\"rtsp://192.168.26.76:8554/\", response=\"f3ce799d94cb45e14bf59e57cd41c749\", algorithm=\"MD5\"";
+        string authStringPLAY_SHA256 = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"729461183\", uri=\"rtsp://192.168.26.76:8554/\", response=\"9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc\", algorithm=\"SHA-256\"";
+        string authStringPLAY_BadAlg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"729461183\", uri=\"rtsp://192.168.26.76:8554/\", response=\"9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc\", algorithm=\"BADVALUE\"";
+        string realm = "SharpRTSPServer";
+        string qop = "";
+
+        [Test]
+        public void IsValid_MD5_No_Alg_Test1()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_MD5_noalg);
+
+            string nonce = "556284985";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var result = testObject.IsValid(message);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void IsValid_MD5_With_Alg_Test()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_MD5_with_alg);
+
+            string nonce = "556284985";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var result = testObject.IsValid(message);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void IsValid_SHA256_Test()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_SHA256);
+
+            string nonce = "729461183";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.SHA256);
+            var result = testObject.IsValid(message);
+
+            Assert.That(result, Is.True);
+        }
+
+        [Test]
+        public void IsValid_BadAlg_Test()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_BadAlg);
+
+            string nonce = "729461183";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var result = testObject.IsValid(message);
+
+            Assert.That(result, Is.False);
+        }
+
+        [Test]
+        public void GetWWWAuthenticate_MD5()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_BadAlg);
+
+            string nonce = "11223344";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var result = testObject.GetServerResponse();
+
+            Assert.That(result.Contains("algorithm"), Is.False); // We don't add 'algorithm=MD5' as it is not required
+        }
+
+        [Test]
+        public void GetWWWAuthenticate_SHA256()
+        {
+            var message = new RtspRequestPlay();
+            message.Headers.Add("Authorization", authStringPLAY_BadAlg);
+
+            string nonce = "11223344";
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.SHA256);
+            var result = testObject.GetServerResponse();
+
+            Assert.That(result.Contains("algorithm") && result.Contains("SHA-256"), Is.True);
+        }
+
+    }
+}

--- a/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
+++ b/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
@@ -9,12 +9,22 @@ namespace RTSP.Tests.Authentication
     public class AuthenticationDigestTests
     {
         // MD5, no Algorithm specified
-        string authStringPLAY_MD5_noalg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"556284985\", uri=\"rtsp://192.168.26.76:8554/\", response=\"f3ce799d94cb45e14bf59e57cd41c749\"";
-        string authStringPLAY_MD5_with_alg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"556284985\", uri=\"rtsp://192.168.26.76:8554/\", response=\"f3ce799d94cb45e14bf59e57cd41c749\", algorithm=\"MD5\"";
-        string authStringPLAY_SHA256 = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"729461183\", uri=\"rtsp://192.168.26.76:8554/\", response=\"9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc\", algorithm=\"SHA-256\"";
-        string authStringPLAY_BadAlg = "Digest username=\"user\", realm=\"SharpRTSPServer\", nonce=\"729461183\", uri=\"rtsp://192.168.26.76:8554/\", response=\"9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc\", algorithm=\"BADVALUE\"";
-        string realm = "SharpRTSPServer";
-        string qop = "";
+        private const string authStringPLAY_MD5_noalg = """
+            Digest username="user", realm="SharpRTSPServer", nonce="556284985", uri="rtsp://192.168.26.76:8554/", response="f3ce799d94cb45e14bf59e57cd41c749"
+            """;
+        private const string authStringPLAY_MD5_with_alg = """
+            Digest username="user", realm="SharpRTSPServer", nonce="556284985", uri="rtsp://192.168.26.76:8554/", response="f3ce799d94cb45e14bf59e57cd41c749", algorithm="MD5"
+            """;
+        private const string authStringPLAY_SHA256 = """
+            Digest username="user", realm="SharpRTSPServer", nonce="729461183", uri="rtsp://192.168.26.76:8554/", response="9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc", algorithm="SHA-256"
+            """;
+
+        private const string authStringPLAY_BadAlg = """
+            Digest username="user", realm="SharpRTSPServer", nonce="729461183", uri="rtsp://192.168.26.76:8554/", response="9f6d99e827799b23b273aaf62f7eea84a720e25a205284a921f0d9aa14621dcc", algorithm="BADVALUE"
+            """;
+        
+        private const string realm = "SharpRTSPServer";
+        private const string qop = "";
 
         [Test]
         public void IsValid_MD5_No_Alg_Test1()
@@ -78,7 +88,7 @@ namespace RTSP.Tests.Authentication
             var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.MD5);
             var result = testObject.GetServerResponse();
 
-            Assert.That(result.Contains("algorithm"), Is.False); // We don't add 'algorithm=MD5' as it is not required
+            Assert.That(result, Does.Not.Contain("algorithm")); // We don't add 'algorithm=MD5' as it is not required
         }
 
         [Test]
@@ -91,7 +101,8 @@ namespace RTSP.Tests.Authentication
             var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.SHA256);
             var result = testObject.GetServerResponse();
 
-            Assert.That(result.Contains("algorithm") && result.Contains("SHA-256"), Is.True);
+            Assert.That(result, Does.Contain("algorithm"));
+            Assert.That(result, Does.Contain("SHA-256"));
         }
 
     }

--- a/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
+++ b/RTSP.Tests/Authentication/AuthenticationDigestTests.cs
@@ -23,7 +23,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_MD5_noalg);
 
             string nonce = "556284985";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.MD5);
             var result = testObject.IsValid(message);
 
             Assert.That(result, Is.True);
@@ -36,7 +36,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_MD5_with_alg);
 
             string nonce = "556284985";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.MD5);
             var result = testObject.IsValid(message);
 
             Assert.That(result, Is.True);
@@ -49,7 +49,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_SHA256);
 
             string nonce = "729461183";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.SHA256);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.SHA256);
             var result = testObject.IsValid(message);
 
             Assert.That(result, Is.True);
@@ -62,7 +62,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_BadAlg);
 
             string nonce = "729461183";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.MD5);
             var result = testObject.IsValid(message);
 
             Assert.That(result, Is.False);
@@ -75,7 +75,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_BadAlg);
 
             string nonce = "11223344";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.MD5);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.MD5);
             var result = testObject.GetServerResponse();
 
             Assert.That(result.Contains("algorithm"), Is.False); // We don't add 'algorithm=MD5' as it is not required
@@ -88,7 +88,7 @@ namespace RTSP.Tests.Authentication
             message.Headers.Add("Authorization", authStringPLAY_BadAlg);
 
             string nonce = "11223344";
-            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HASH_ALGORITHM.SHA256);
+            var testObject = new AuthenticationDigest(new NetworkCredential("user", "password", realm), realm, nonce, qop, AuthenticationDigest.HashAlgorithm.SHA256);
             var result = testObject.GetServerResponse();
 
             Assert.That(result.Contains("algorithm") && result.Contains("SHA-256"), Is.True);

--- a/RTSP/Authentication.cs
+++ b/RTSP/Authentication.cs
@@ -55,7 +55,17 @@ namespace Rtsp
                         throw new ArgumentException("\"nonce\" parameter is not found in header", nameof(authenticateHeader));
 
                     parameterNameToValueMap.TryGetValue("QOP", out var qop);
-                    return new AuthenticationDigest(credential, realm, nonce, qop);
+
+                    // algorithm parameter is optional (and we default to MD5 if it is not present)
+                    AuthenticationDigest.HASH_ALGORITHM algorithm = AuthenticationDigest.HASH_ALGORITHM.MD5;
+                    if (parameterNameToValueMap.TryGetValue("ALGORITHM", out var algorithm_string))
+                    {
+                        if (string.Equals(algorithm_string, "SHA-256")) algorithm = AuthenticationDigest.HASH_ALGORITHM.SHA256;
+                        else if (string.Equals(algorithm_string, "MD5")) algorithm = AuthenticationDigest.HASH_ALGORITHM.MD5;
+                        else throw new ArgumentException("\"algorithm\" parameter invalid", nameof(authenticateHeader));
+                    }
+
+                    return new AuthenticationDigest(credential, realm, nonce, qop, algorithm);
                 }
             }
 

--- a/RTSP/Authentication.cs
+++ b/RTSP/Authentication.cs
@@ -57,11 +57,11 @@ namespace Rtsp
                     parameterNameToValueMap.TryGetValue("QOP", out var qop);
 
                     // algorithm parameter is optional (and we default to MD5 if it is not present)
-                    AuthenticationDigest.HASH_ALGORITHM algorithm = AuthenticationDigest.HASH_ALGORITHM.MD5;
+                    AuthenticationDigest.HashAlgorithm algorithm = AuthenticationDigest.HashAlgorithm.MD5;
                     if (parameterNameToValueMap.TryGetValue("ALGORITHM", out var algorithm_string))
                     {
-                        if (string.Equals(algorithm_string, "SHA-256")) algorithm = AuthenticationDigest.HASH_ALGORITHM.SHA256;
-                        else if (string.Equals(algorithm_string, "MD5")) algorithm = AuthenticationDigest.HASH_ALGORITHM.MD5;
+                        if (string.Equals(algorithm_string, "SHA-256")) algorithm = AuthenticationDigest.HashAlgorithm.SHA256;
+                        else if (string.Equals(algorithm_string, "MD5")) algorithm = AuthenticationDigest.HashAlgorithm.MD5;
                         else throw new ArgumentException("\"algorithm\" parameter invalid", nameof(authenticateHeader));
                     }
 

--- a/RTSP/AuthenticationDigest.cs
+++ b/RTSP/AuthenticationDigest.cs
@@ -10,12 +10,15 @@ namespace Rtsp
     // WWW-Authentication and Authorization Headers
     public class AuthenticationDigest : Authentication
     {
+        public enum HASH_ALGORITHM { MD5, SHA256 };
+
         private readonly string _realm;
         private readonly string _nonce;
         private readonly string? _qop;
         private readonly string _cnonce;
+        private readonly HASH_ALGORITHM _algorithm;
 
-        public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop) : base(credentials)
+        public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop, HASH_ALGORITHM algorithm) : base(credentials)
         {
             _realm = realm ?? throw new ArgumentNullException(nameof(realm));
             _nonce = nonce ?? throw new ArgumentNullException(nameof(nonce));
@@ -27,40 +30,53 @@ namespace Rtsp
             }
             uint cnonce = (uint)Guid.NewGuid().GetHashCode();
             _cnonce = cnonce.ToString("X8");
+            _algorithm = algorithm;
         }
 
         public override string GetServerResponse()
         {
             //TODO implement correctly
-            return $"Digest realm=\"{_realm}\", nonce=\"{_nonce}\"";
+            string result = $"Digest realm=\"{_realm}\", nonce=\"{_nonce}\"";
+
+            // algorithm defaults to MD5 (some clients may not expect an algorithm=MD5 parameter
+            if (_algorithm == HASH_ALGORITHM.SHA256) result += $", algorithm=SHA-256";
+            return result;
         }
 
         public override string GetResponse(uint nonceCounter, string uri, string method,
             byte[] entityBodyBytes)
         {
-            MD5 md5 = MD5.Create();
-            string ha1 = CalculateMD5Hash(md5, $"{Credentials.UserName}:{_realm}:{Credentials.Password}");
+            HashAlgorithm hashAlgorithm;
+            if (_algorithm == HASH_ALGORITHM.SHA256)
+                hashAlgorithm = SHA256.Create();
+            else /* default is MD5 */
+                hashAlgorithm = MD5.Create();
+
+            string ha1 = CalculateHash(hashAlgorithm, $"{Credentials.UserName}:{_realm}:{Credentials.Password}");
             string ha2Argument = $"{method}:{uri}";
             bool hasQop = !string.IsNullOrEmpty(_qop);
 
             if (hasQop && _qop!.Equals("auth-int", StringComparison.InvariantCultureIgnoreCase))
             {
-                ha2Argument = $"{ha2Argument}:{CalculateMD5Hash(md5, entityBodyBytes)}";
+                ha2Argument = $"{ha2Argument}:{CalculateHash(hashAlgorithm, entityBodyBytes)}";
             }
-            string ha2 = CalculateMD5Hash(md5, ha2Argument);
+            string ha2 = CalculateHash(hashAlgorithm, ha2Argument);
 
             StringBuilder sb = new();
             sb.AppendFormat(CultureInfo.InvariantCulture, "Digest username=\"{0}\", realm=\"{1}\", nonce=\"{2}\", uri=\"{3}\"", Credentials.UserName, _realm, _nonce, uri);
             if (!hasQop)
             {
-                string response = CalculateMD5Hash(md5, $"{ha1}:{_nonce}:{ha2}");
+                string response = CalculateHash(hashAlgorithm, $"{ha1}:{_nonce}:{ha2}");
                 sb.AppendFormat(CultureInfo.InvariantCulture, ", response=\"{0}\"", response);
             }
             else
             {
-                string response = CalculateMD5Hash(md5, $"{ha1}:{_nonce}:{nonceCounter:X8}:{_cnonce}:{_qop}:{ha2}");
+                string response = CalculateHash(hashAlgorithm, $"{ha1}:{_nonce}:{nonceCounter:X8}:{_cnonce}:{_qop}:{ha2}");
                 sb.AppendFormat(CultureInfo.InvariantCulture, ", response=\"{0}\", cnonce=\"{1}\", nc=\"{2:X8}\", qop=\"{3}\"", response, _cnonce, nonceCounter, _qop);
             }
+
+            hashAlgorithm.Dispose();
+
             return sb.ToString();
         }
         public override bool IsValid(RtspRequest receivedMessage)
@@ -77,6 +93,7 @@ namespace Rtsp
                 string? nonce = null;
                 string? uri = null;
                 string? response = null;
+                HASH_ALGORITHM algorithm = HASH_ALGORITHM.MD5; // algorithm is optional, and defaults to MD5
 
                 foreach (string value in valueStr.Split(','))
                 {
@@ -106,14 +123,25 @@ namespace Rtsp
                     {
                         response = var;
                     }
+                    else if (tuple[0].Equals("algorithm", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (String.Equals(var, "MD5")) algorithm = HASH_ALGORITHM.MD5;
+                        else if (String.Equals(var,"SHA-256")) algorithm = HASH_ALGORITHM.SHA256;
+                    }
                 }
 
                 // Create the MD5 Hash using all parameters passed in the Auth Header with the 
                 // addition of the 'Password'
-                MD5 md5 = MD5.Create();
-                string hashA1 = CalculateMD5Hash(md5, username + ":" + realm + ":" + Credentials.Password);
-                string hashA2 = CalculateMD5Hash(md5, receivedMessage.RequestTyped + ":" + uri);
-                string expectedResponse = CalculateMD5Hash(md5, hashA1 + ":" + nonce + ":" + hashA2);
+                HashAlgorithm hashAlgorithm;
+                if (algorithm == HASH_ALGORITHM.SHA256)
+                    hashAlgorithm = SHA256.Create();
+                else /* Default to MD5 */
+                    hashAlgorithm = MD5.Create();
+
+                string hashA1 = CalculateHash(hashAlgorithm, username + ":" + realm + ":" + Credentials.Password);
+                string hashA2 = CalculateHash(hashAlgorithm, receivedMessage.RequestTyped + ":" + uri);
+                string expectedResponse = CalculateHash(hashAlgorithm, hashA1 + ":" + nonce + ":" + hashA2);
+                hashAlgorithm.Dispose();
 
                 // Check if everything matches
                 // ToDo - extract paths from the URIs (ignoring SETUP's trackID)
@@ -125,15 +153,14 @@ namespace Rtsp
             return false;
         }
 
-        // MD5 (lower case)
-        private static string CalculateMD5Hash(MD5 md5_session, string input)
+        private static string CalculateHash(HashAlgorithm hashAlgorithm, string input)
         {
             byte[] inputBytes = Encoding.UTF8.GetBytes(input);
-            return CalculateMD5Hash(md5_session, inputBytes);
+            return CalculateHash(hashAlgorithm, inputBytes);
         }
-        private static string CalculateMD5Hash(MD5 md5_session, byte[] input)
+        private static string CalculateHash(HashAlgorithm hashAlgorithm, byte[] input)
         {
-            byte[] hash = md5_session.ComputeHash(input);
+            byte[] hash = hashAlgorithm.ComputeHash(input);
 
             var output = new StringBuilder();
             foreach (var t in hash)

--- a/RTSP/AuthenticationDigest.cs
+++ b/RTSP/AuthenticationDigest.cs
@@ -18,6 +18,11 @@ namespace Rtsp
         private readonly string _cnonce;
         private readonly HASH_ALGORITHM _algorithm;
 
+        public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop) :
+            this(credentials, realm, nonce, qop, HASH_ALGORITHM.MD5)
+        {
+        }
+
         public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop, HASH_ALGORITHM algorithm) : base(credentials)
         {
             _realm = realm ?? throw new ArgumentNullException(nameof(realm));

--- a/RTSP/AuthenticationDigest.cs
+++ b/RTSP/AuthenticationDigest.cs
@@ -10,20 +10,20 @@ namespace Rtsp
     // WWW-Authentication and Authorization Headers
     public class AuthenticationDigest : Authentication
     {
-        public enum HASH_ALGORITHM { MD5, SHA256 };
+        public enum HashAlgorithm { MD5, SHA256 };
 
         private readonly string _realm;
         private readonly string _nonce;
         private readonly string? _qop;
         private readonly string _cnonce;
-        private readonly HASH_ALGORITHM _algorithm;
+        private readonly HashAlgorithm _algorithm;
 
         public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop) :
-            this(credentials, realm, nonce, qop, HASH_ALGORITHM.MD5)
+            this(credentials, realm, nonce, qop, HashAlgorithm.MD5)
         {
         }
 
-        public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop, HASH_ALGORITHM algorithm) : base(credentials)
+        public AuthenticationDigest(NetworkCredential credentials, string realm, string nonce, string? qop, HashAlgorithm algorithm) : base(credentials)
         {
             _realm = realm ?? throw new ArgumentNullException(nameof(realm));
             _nonce = nonce ?? throw new ArgumentNullException(nameof(nonce));
@@ -44,15 +44,15 @@ namespace Rtsp
             string result = $"Digest realm=\"{_realm}\", nonce=\"{_nonce}\"";
 
             // algorithm defaults to MD5 (some clients may not expect an algorithm=MD5 parameter
-            if (_algorithm == HASH_ALGORITHM.SHA256) result += $", algorithm=SHA-256";
+            if (_algorithm == HashAlgorithm.SHA256) result += $", algorithm=SHA-256";
             return result;
         }
 
         public override string GetResponse(uint nonceCounter, string uri, string method,
             byte[] entityBodyBytes)
         {
-            HashAlgorithm hashAlgorithm;
-            if (_algorithm == HASH_ALGORITHM.SHA256)
+            System.Security.Cryptography.HashAlgorithm hashAlgorithm;
+            if (_algorithm == HashAlgorithm.SHA256)
                 hashAlgorithm = SHA256.Create();
             else /* default is MD5 */
                 hashAlgorithm = MD5.Create();
@@ -98,7 +98,7 @@ namespace Rtsp
                 string? nonce = null;
                 string? uri = null;
                 string? response = null;
-                HASH_ALGORITHM algorithm = HASH_ALGORITHM.MD5; // algorithm is optional, and defaults to MD5
+                HashAlgorithm algorithm = HashAlgorithm.MD5; // algorithm is optional, and defaults to MD5
 
                 foreach (string value in valueStr.Split(','))
                 {
@@ -130,15 +130,15 @@ namespace Rtsp
                     }
                     else if (tuple[0].Equals("algorithm", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (String.Equals(var, "MD5")) algorithm = HASH_ALGORITHM.MD5;
-                        else if (String.Equals(var,"SHA-256")) algorithm = HASH_ALGORITHM.SHA256;
+                        if (String.Equals(var, "MD5")) algorithm = HashAlgorithm.MD5;
+                        else if (String.Equals(var,"SHA-256")) algorithm = HashAlgorithm.SHA256;
                     }
                 }
 
                 // Create the MD5 Hash using all parameters passed in the Auth Header with the 
                 // addition of the 'Password'
-                HashAlgorithm hashAlgorithm;
-                if (algorithm == HASH_ALGORITHM.SHA256)
+                System.Security.Cryptography.HashAlgorithm hashAlgorithm;
+                if (algorithm == HashAlgorithm.SHA256)
                     hashAlgorithm = SHA256.Create();
                 else /* Default to MD5 */
                     hashAlgorithm = MD5.Create();
@@ -158,12 +158,12 @@ namespace Rtsp
             return false;
         }
 
-        private static string CalculateHash(HashAlgorithm hashAlgorithm, string input)
+        private static string CalculateHash(System.Security.Cryptography.HashAlgorithm hashAlgorithm, string input)
         {
             byte[] inputBytes = Encoding.UTF8.GetBytes(input);
             return CalculateHash(hashAlgorithm, inputBytes);
         }
-        private static string CalculateHash(HashAlgorithm hashAlgorithm, byte[] input)
+        private static string CalculateHash(System.Security.Cryptography.HashAlgorithm hashAlgorithm, byte[] input)
         {
             byte[] hash = hashAlgorithm.ComputeHash(input);
 

--- a/RTSP/AuthenticationDigest.cs
+++ b/RTSP/AuthenticationDigest.cs
@@ -51,11 +51,7 @@ namespace Rtsp
         public override string GetResponse(uint nonceCounter, string uri, string method,
             byte[] entityBodyBytes)
         {
-            System.Security.Cryptography.HashAlgorithm hashAlgorithm;
-            if (_algorithm == HashAlgorithm.SHA256)
-                hashAlgorithm = SHA256.Create();
-            else /* default is MD5 */
-                hashAlgorithm = MD5.Create();
+            using var hashAlgorithm = CreateHashAlgorithm(_algorithm);
 
             string ha1 = CalculateHash(hashAlgorithm, $"{Credentials.UserName}:{_realm}:{Credentials.Password}");
             string ha2Argument = $"{method}:{uri}";
@@ -79,8 +75,6 @@ namespace Rtsp
                 string response = CalculateHash(hashAlgorithm, $"{ha1}:{_nonce}:{nonceCounter:X8}:{_cnonce}:{_qop}:{ha2}");
                 sb.AppendFormat(CultureInfo.InvariantCulture, ", response=\"{0}\", cnonce=\"{1}\", nc=\"{2:X8}\", qop=\"{3}\"", response, _cnonce, nonceCounter, _qop);
             }
-
-            hashAlgorithm.Dispose();
 
             return sb.ToString();
         }
@@ -137,16 +131,11 @@ namespace Rtsp
 
                 // Create the MD5 Hash using all parameters passed in the Auth Header with the 
                 // addition of the 'Password'
-                System.Security.Cryptography.HashAlgorithm hashAlgorithm;
-                if (algorithm == HashAlgorithm.SHA256)
-                    hashAlgorithm = SHA256.Create();
-                else /* Default to MD5 */
-                    hashAlgorithm = MD5.Create();
+                using var hashAlgorithm = CreateHashAlgorithm(algorithm);
 
                 string hashA1 = CalculateHash(hashAlgorithm, username + ":" + realm + ":" + Credentials.Password);
                 string hashA2 = CalculateHash(hashAlgorithm, receivedMessage.RequestTyped + ":" + uri);
                 string expectedResponse = CalculateHash(hashAlgorithm, hashA1 + ":" + nonce + ":" + hashA2);
-                hashAlgorithm.Dispose();
 
                 // Check if everything matches
                 // ToDo - extract paths from the URIs (ignoring SETUP's trackID)
@@ -157,6 +146,14 @@ namespace Rtsp
             }
             return false;
         }
+
+        private static System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm(HashAlgorithm algorithm) =>
+            algorithm switch
+            {
+                HashAlgorithm.SHA256 => SHA256.Create(),
+                /* default is MD5 */
+                _ => MD5.Create(),
+            };
 
         private static string CalculateHash(System.Security.Cryptography.HashAlgorithm hashAlgorithm, string input)
         {

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -84,7 +84,7 @@ namespace RtspCameraExample
                 // There is also an ONVIF "MD5 then SHA-256" which sends two WWW-Autneiticate headers
                 // which is not yet supported.
                 var useSHA256 = false;
-                var algorithm = (useSHA256 ? AuthenticationDigest.HASH_ALGORITHM.SHA256 : AuthenticationDigest.HASH_ALGORITHM.MD5);
+                var algorithm = (useSHA256 ? AuthenticationDigest.HashAlgorithm.SHA256 : AuthenticationDigest.HashAlgorithm.MD5);
                 auth = new AuthenticationDigest(credential, realm, new Random().Next(100000000, 999999999).ToString(), string.Empty, algorithm);
             }
             else

--- a/RtspCameraExample/RtspServer.cs
+++ b/RtspCameraExample/RtspServer.cs
@@ -78,7 +78,14 @@ namespace RtspCameraExample
             {
                 const string realm = "SharpRTSPServer";
                 credential = new(username, password);
-                auth = new AuthenticationDigest(credential, realm, new Random().Next(100000000, 999999999).ToString(), string.Empty);
+                // The original RFC for Digest Auth used the MD5 Hash Algorithm
+                // There is a newer RFC that allows the SHA-256 Hash Algorithm
+                // Enable SHA-256 for some FIPS setups
+                // There is also an ONVIF "MD5 then SHA-256" which sends two WWW-Autneiticate headers
+                // which is not yet supported.
+                var useSHA256 = false;
+                var algorithm = (useSHA256 ? AuthenticationDigest.HASH_ALGORITHM.SHA256 : AuthenticationDigest.HASH_ALGORITHM.MD5);
+                auth = new AuthenticationDigest(credential, realm, new Random().Next(100000000, 999999999).ToString(), string.Empty, algorithm);
             }
             else
             {


### PR DESCRIPTION
The ONVIF Standard now includes SHA-256 as well as MD5 for Digest Authentication.
This change adds the ability to enable SHA-256 in the RtspCameraExample code.

It is tested with a patched ffmpeg library which adds SHA-256

There is one more change to follow, but that will be in a different PR.
That is where we have multiple WWW-Authenticate headers and tell RTSP clients that we can do both MD5 and SHA256, like some HikVision camera have, but that is for another time.

It has been a long time since I've done any Unit Tests so just wanted someone to cast their eye over this.

Thanks
Roger
