### PR TITLE
B Fixed ArgumentOutOfRangeException

### DIFF
--- a/RTSP/RTSPListener.cs
+++ b/RTSP/RTSPListener.cs
@@ -366,7 +366,7 @@ namespace Rtsp
             {
                 if (buffer.Length >= currentMessage.Data.Length)
                 {
-                    buffer.CopyTo(currentMessage.Data.Span);
+                    buffer.Slice(0, currentMessage.Data.Length).CopyTo(currentMessage.Data.Span);
                     buffer = buffer.Slice(currentMessage.Data.Length);
                     return ReadingMessage.MessageFinish;
                 }


### PR DESCRIPTION
Fixed ArgumentOutOfRangeException being thrown from CopyTo when buffer.Length > currentMessage.Data.Length. I cannot reproduce it myself, but it is most likely the root cause of https://github.com/jimm98y/SharpRTSPtoWebRTC/issues/24.